### PR TITLE
Remove version field from compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   app:
     build: .


### PR DESCRIPTION
## Summary
- clean up docker-compose.yml by removing unneeded `version` field

## Testing
- `pnpm test`
- `pnpm lint` *(fails: config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6851a491df508327bdf5ca0dcb25cec4