### PR TITLE
Enable corepack before build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN pnpm build
+RUN corepack enable && pnpm build
 
 # Production image
 FROM node:20-alpine AS runner


### PR DESCRIPTION
## Summary
- configure Docker builder stage to enable Corepack before building

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6851a4482b208327bf92c8a3944ad479