### PR TITLE
Fix unescaped apostrophe in Hero

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -15,7 +15,7 @@ export default function Hero() {
         transition={{ duration: 0.7 }}
         className="text-4xl md:text-6xl font-display font-extrabold leading-tight"
       >
-        Salut, moi c'est <span className="text-primary">Victor Lenain</span>
+        Salut, moi c&apos;est <span className="text-primary">Victor Lenain</span>
         <br />
         Développeur Web & Ingénieur DevOps
       </motion.h1>


### PR DESCRIPTION
## Summary
- escape single quote in `Hero` component to satisfy `react/no-unescaped-entities`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6851a7ddc8848327be10409104c113f9