### PR TITLE
Add shadcn utility helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ pnpm create next-app@latest mon-portfolio
 # ou yarn create next-app, npm create next-app
 # Copie ensuite les fichiers de ce repo ou clone-le
 pnpm i
-pnpm dlx shadcn-ui@latest init
+pnpm dlx shadcn@latest init
 pnpm dev
 ```
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,4 @@
+@import "tailwindcss-animate";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/components.json
+++ b/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-import { clsx } from 'clsx'
+import { cn } from '@/lib/utils'
 
 export function Badge({
   children,
@@ -9,7 +9,7 @@ export function Badge({
 }) {
   return (
     <span
-      className={clsx(
+      className={cn(
         'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold',
         variant === 'default'
           ? 'bg-primary text-primary-foreground'

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
-import { clsx } from 'clsx'
+import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
   'inline-flex items-center justify-center rounded-2xl text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
@@ -41,7 +41,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : 'button'
     return (
       <Comp
-        className={clsx(buttonVariants({ variant, size }), className)}
+        className={cn(buttonVariants({ variant, size }), className)}
         ref={ref}
         {...props}
       />

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,10 +1,10 @@
-import { clsx } from 'clsx'
+import { cn } from '@/lib/utils'
 import { ReactNode } from 'react'
 
 export function Card({ className, children }: { className?: string; children: ReactNode }) {
-  return <div className={clsx('bg-gray-800/50 border border-gray-700 rounded-2xl shadow', className)}>{children}</div>
+  return <div className={cn('bg-gray-800/50 border border-gray-700 rounded-2xl shadow', className)}>{children}</div>
 }
 
 export function CardContent({ className, children }: { className?: string; children: ReactNode }) {
-  return <div className={clsx('p-4', className)}>{children}</div>
+  return <div className={cn('p-4', className)}>{children}</div>
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
@@ -22,19 +22,21 @@
     "postcss": "8.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tailwindcss": "4.1.10"
+    "tailwind-merge": "^2.6.0",
+    "tailwindcss": "4.1.10",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^20.19.1",
     "@types/react": "^18.3.23",
+    "@vitejs/plugin-react": "^4.5.2",
     "eslint": "9.29.0",
     "eslint-config-next": "15.3.3",
     "typescript": "5.5.2",
     "vite": "^6.3.5",
-    "vitest": "^3.2.4",
-    "@vitejs/plugin-react": "^4.5.2"
+    "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,15 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      tailwind-merge:
+        specifier: ^2.6.0
+        version: 2.6.0
       tailwindcss:
         specifier: 4.1.10
         version: 4.1.10
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@4.1.10)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.6.3
@@ -2313,6 +2319,14 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwind-merge@2.6.0:
+    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
+
+  tailwindcss-animate@1.0.7:
+    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
 
   tailwindcss@4.1.10:
     resolution: {integrity: sha512-P3nr6WkvKV/ONsTzj6Gb57sWPMX29EPNPopo7+FcpkQaNsrNpZ1pv8QmrYI2RqEKD7mlGqLnGovlcYnBK0IqUA==}
@@ -4984,6 +4998,12 @@ snapshots:
 
   symbol-tree@3.2.4:
     optional: true
+
+  tailwind-merge@2.6.0: {}
+
+  tailwindcss-animate@1.0.7(tailwindcss@4.1.10):
+    dependencies:
+      tailwindcss: 4.1.10
 
   tailwindcss@4.1.10: {}
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,5 +22,5 @@ module.exports = {
       }
     }
   },
-  plugins: [require('@tailwindcss/typography')]
+  plugins: [require('@tailwindcss/typography'), require('tailwindcss-animate')]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '.')
+    }
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- create `lib/utils.ts` and add `tailwind-merge`
- switch UI components to use the new `cn` helper
- update vite config to support path alias
- modernize README instructions for shadcn
- run tests via `vitest run`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6852c2d719348327bf3e3280b7b86f41