### PR TITLE
Remove unused import in global CSS

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,3 @@
-@import "tailwindcss-animate";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- clean up Tailwind setup by removing an unused `tailwindcss-animate` import

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6852cd94c48c832781ea378d488489ca