### PR TITLE
Switch to Bun and run ESLint with Oxlint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/core-web-vitals", "plugin:oxlint/recommended"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ node_modules/
 .pnpm/
 .next/
 
+bun.lock
+.bun/
+.eslintcache

--- a/README.md
+++ b/README.md
@@ -3,13 +3,23 @@
 ## Démarrage rapide
 
 ```bash
-pnpm create next-app@latest mon-portfolio
+bun create next-app mon-portfolio
 # ou yarn create next-app, npm create next-app
 # Copie ensuite les fichiers de ce repo ou clone-le
-pnpm i
-pnpm dlx shadcn@latest init
-pnpm dev
+bun install
+bunx shadcn@latest init
+bun run dev
 ```
+
+## Vérifier le code
+
+```bash
+bun run lint
+bun run test
+```
+
+`bun run lint` exécute d'abord [Oxlint](https://oxc.rs) puis ESLint via Next.js grâce au plugin
+[`eslint-plugin-oxlint`](https://github.com/oxc-project/eslint-plugin-oxlint).
 
 ## Principales dépendances
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "test": "vitest run"
+    "dev": "bun x next dev",
+    "build": "bun x next build",
+    "start": "bun x next start",
+    "lint": "bun x oxlint . && ESLINT_USE_FLAT_CONFIG=false bun x eslint .",
+    "test": "bun x vitest run"
   },
   "dependencies": {
     "@radix-ui/react-navigation-menu": "^1.2.13",
@@ -32,11 +32,14 @@
     "@types/node": "^20.19.1",
     "@types/react": "^18.3.23",
     "@vitejs/plugin-react": "^4.5.2",
-    "eslint": "9.29.0",
-    "eslint-config-next": "15.3.3",
+    "oxlint": "^1.2.0",
     "typescript": "5.5.2",
     "vite": "^6.3.5",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "jsdom": "^24.0.0",
+    "eslint": "9.29.0",
+    "eslint-config-next": "15.3.3",
+    "eslint-plugin-oxlint": "^1.2.0"
   },
-  "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
+  "packageManager": "bun@1.2.14"
 }


### PR DESCRIPTION
## Summary
- combine Oxlint with ESLint via eslint-plugin-oxlint
- keep Next.js lint rules using `.eslintrc.json`
- ignore `.eslintcache`
- document lint and test commands

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_6853dea21a608327b9673a5c7cad2626