### PR TITLE
Fix project alt text

### DIFF
--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -40,7 +40,7 @@ export default function Projects() {
             <Card className="overflow-hidden">
               <Image
                 src={project.image}
-                alt=""
+                alt={project.title}
                 width={800}
                 height={450}
                 className="transition-transform group-hover:scale-105"


### PR DESCRIPTION
## Summary
- improve accessibility for `<Image>` by using the project title for alt text

## Testing
- `bun test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68542141150c8327a8e21314c3046025