### PR TITLE
Add cube entrance animation

### DIFF
--- a/components/ThreeHero.tsx
+++ b/components/ThreeHero.tsx
@@ -7,14 +7,19 @@ import { useFrame } from '@react-three/fiber'
 
 function Box() {
   const mesh = useRef<Mesh>(null)
-  useFrame(() => {
+  const scale = useRef(0)
+  useFrame((_, delta) => {
     if (mesh.current) {
+      if (scale.current < 1) {
+        scale.current = Math.min(scale.current + delta, 1)
+        mesh.current.scale.setScalar(scale.current)
+      }
       mesh.current.rotation.x += 0.01
       mesh.current.rotation.y += 0.01
     }
   })
   return (
-    <mesh ref={mesh}>
+    <mesh ref={mesh} scale={0}>
       <boxGeometry args={[1, 1, 1]} />
       <meshStandardMaterial color="orange" />
     </mesh>


### PR DESCRIPTION
## Summary
- animate the Three.js cube scaling so it appears smoothly

## Testing
- `bun test` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68542e8dbef88327b0d5c44dd4c68a3f