### PR TITLE
Add fade in for ThreeHero cube

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -35,9 +35,14 @@ export default function Hero() {
         cloud robustes et des apps React performantes.
       </motion.p>
 
-      <div className="w-full max-w-md mt-10">
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.25, duration: 0.7 }}
+        className="w-full max-w-md mt-10"
+      >
         <ThreeHero />
-      </div>
+      </motion.div>
 
       <motion.div
         initial={{ opacity: 0, y: 16 }}


### PR DESCRIPTION
## Summary
- wrap `ThreeHero` with `motion.div` in `Hero.tsx` to make the cube appear
  with the same fade/slide effect as the text

## Testing
- `bun test` *(fails: Cannot find module 'react/jsx-dev-runtime')*


------
https://chatgpt.com/codex/tasks/task_e_685430eef0548327b1fbe47dce34e987