### PR TITLE
Fix hero cube layout shift

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -6,6 +6,8 @@ import { ArrowRight } from 'lucide-react'
 
 const ThreeHero = dynamic(() => import('@/components/ThreeHero'), {
   ssr: false,
+  // Reserve space while loading to avoid layout shift
+  loading: () => <div className="w-full h-96" />,
 })
 
 export default function Hero() {


### PR DESCRIPTION
## Summary
- show placeholder while dynamic cube component loads to keep layout stable

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_685432557ed483278a46ebbfb5b576b4