### PR TITLE
Add spinner fallback for Three.js hero

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -3,11 +3,16 @@ import { motion } from 'framer-motion'
 import dynamic from 'next/dynamic'
 import { Button } from '@/components/ui/button'
 import { ArrowRight } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 
 const ThreeHero = dynamic(() => import('@/components/ThreeHero'), {
   ssr: false,
-  // Reserve space while loading to avoid layout shift
-  loading: () => <div className="w-full h-96" />,
+  // Display a spinner while loading to avoid layout shift
+  loading: () => (
+    <div className="w-full h-96 flex items-center justify-center">
+      <Spinner className="size-10 text-primary" />
+    </div>
+  ),
 })
 
 export default function Hero() {

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Spinner({ className, ...props }: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      className={cn("animate-spin", className)}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  )
+}
+
+export { Spinner }


### PR DESCRIPTION
## Summary
- show a spinner while loading the Three.js canvas
- add a small `Spinner` component

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_68543486eca48327b0077ddfa75c4a54