### PR TITLE
Add shadcn spinner while loading Three.js

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,16 +1,31 @@
 'use client'
 import { motion } from 'framer-motion'
 import dynamic from 'next/dynamic'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
 import { ArrowRight } from 'lucide-react'
 
 const ThreeHero = dynamic(() => import('@/components/ThreeHero'), {
   ssr: false,
-  // Reserve space while loading to avoid layout shift
-  loading: () => <div className="w-full h-96" />,
+  loading: () => null,
 })
 
 export default function Hero() {
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    import('./ThreeHero').then(() => setLoaded(true))
+  }, [])
+
+  if (!loaded) {
+    return (
+      <section id="accueil" className="h-screen flex items-center justify-center">
+        <Spinner className="size-10" />
+      </section>
+    )
+  }
+
   return (
     <section
       id="accueil"

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils"
+import * as React from "react"
+
+export function Spinner({ className, ...props }: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      data-slot="spinner"
+      className={cn("animate-spin text-primary", className)}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple `Spinner` component in the UI library
- show a centered spinner until the Three.js hero is loaded

## Testing
- `bun lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6854482bdddc8327b8e92016d068059e