### PR TITLE
feat: add pastel palette and transitions

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -2,26 +2,26 @@ import Section from '@/components/Section';
 
 export default function About() {
   return (
-    <Section id="a-propos" className="scroll-mt-28 pb-28">
-      <h2 className="mb-4 font-display text-3xl font-bold text-indigo-400">
+    <Section id="a-propos" className="scroll-mt-28 pb-28 transition-colors duration-300">
+      <h2 className="mb-4 font-display text-3xl font-bold text-soft-blue-300 transition-colors duration-300">
         À&nbsp;propos
       </h2>
 
-      <p className="max-w-xl leading-relaxed text-gray-300">
+      <p className="max-w-xl leading-relaxed text-soft-gray-300 transition-colors duration-300">
         Développeur&nbsp;full-stack&nbsp;JavaScript diplômé du&nbsp;
-        <span className="font-semibold text-indigo-400">
+        <span className="font-semibold text-soft-blue-300 transition-colors duration-300">
           Wagon
         </span>{' '}
         et d&apos;&nbsp;
-        <span className="font-semibold text-indigo-400">OpenClassrooms</span>,
+        <span className="font-semibold text-soft-blue-300 transition-colors duration-300">OpenClassrooms</span>,
         avec&nbsp;
-        <span className="font-semibold text-indigo-400">
+        <span className="font-semibold text-soft-blue-300 transition-colors duration-300">
           3 années d&apos;expérience
         </span>{' '}
         en développement web. Spécialisé dans les technologies modernes
         et la création de solutions innovantes, je développe continuellement
         mes compétences à travers des&nbsp;
-        <span className="font-semibold text-indigo-400">
+        <span className="font-semibold text-soft-blue-300 transition-colors duration-300">
           projets open-source
         </span>
         .
@@ -38,13 +38,13 @@ export default function About() {
         ).map(([val, label]) => (
           <li
             key={label}
-            className="rounded-2xl bg-gray-900/60 p-4 text-center"
+            className="rounded-2xl bg-soft-blue-100/50 p-4 text-center transition-colors duration-300"
           >
-            <span className="block text-2xl font-bold text-indigo-400">
+            <span className="block text-2xl font-bold text-soft-blue-300 transition-colors duration-300">
               {val}
             </span>
             <span
-              className="text-sm text-gray-400"
+              className="text-sm text-soft-gray-300 transition-colors duration-300"
               dangerouslySetInnerHTML={{ __html: label ?? '' }}
             />
           </li>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -16,7 +16,7 @@ export default function Hero() {
   return (
     <section
       id="accueil"
-      className="relative flex min-h-[100svh] flex-col items-center overflow-hidden pt-[calc(3.5rem+env(safe-area-inset-top))] sm:pt-0"
+      className="relative flex min-h-[100svh] flex-col items-center overflow-hidden pt-[calc(3.5rem+env(safe-area-inset-top))] sm:pt-0 transition-colors duration-300"
     >
       {/* ── Contenu principal ─────────────────────────────────────── */}
       <div className="mx-auto flex max-w-7xl flex-col gap-14 px-0 sm:items-center sm:gap-10 sm:px-8 lg:grid lg:min-h-[70vh] lg:grid-cols-2 lg:place-items-center lg:gap-16 lg:px-20">
@@ -33,13 +33,13 @@ export default function Hero() {
           </h1>
 
           <div className="mb-3 flex items-center gap-3 sm:justify-center">
-            <span className="h-1 w-8 rounded-full bg-gradient-to-r from-[#6bb4d8] via-[#4288b7] to-[#2d5e81]" />
-            <p className="text-sm font-medium uppercase tracking-wide text-indigo-200 sm:text-base">
+            <span className="h-1 w-8 rounded-full bg-gradient-to-r from-soft-blue-300 via-soft-blue-200 to-soft-gray-200" />
+            <p className="text-sm font-medium uppercase tracking-wide text-soft-blue-200 sm:text-base transition-colors duration-300">
               Développeur&nbsp;Full-Stack
             </p>
           </div>
 
-          <p className="hidden max-w-[28ch] text-sm text-gray-300 sm:block sm:max-w-md sm:text-base">
+          <p className="hidden max-w-[28ch] text-sm text-soft-gray-300 sm:block sm:max-w-md sm:text-base transition-colors duration-300">
             Conception et développement d&apos;applications web modernes,
             d&apos;expériences&nbsp;3D et de solutions&nbsp;IA.
           </p>
@@ -106,7 +106,7 @@ export default function Hero() {
       <a
         href="#a-propos"
         aria-label="Faire défiler vers la section À propos"
-        className="absolute bottom-[calc(1.5rem+env(safe-area-inset-bottom))] left-1/2 -translate-x-1/2 text-white/80 transition-opacity hover:opacity-100"
+        className="absolute bottom-[calc(1.5rem+env(safe-area-inset-bottom))] left-1/2 -translate-x-1/2 text-soft-gray-200/80 transition-opacity transition-colors duration-300 hover:opacity-100"
         onClick={e => {
           e.preventDefault();
           document

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -44,6 +44,16 @@ export default {
         border: 'hsl(var(--color-border) / <alpha-value>)',
         input: 'hsl(var(--color-input) / <alpha-value>)',
         ring: 'hsl(var(--color-ring) / <alpha-value>)',
+        'soft-blue': {
+          100: '#dbeafe',
+          200: '#bfdbfe',
+          300: '#93c5fd',
+        },
+        'soft-gray': {
+          100: '#f5f5f5',
+          200: '#e5e7eb',
+          300: '#d1d5db',
+        },
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Summary
- introduce soft blue and gray palette in Tailwind config
- update Hero and About components to use pastel tones with smooth color transitions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a245211883279f91b87f8572bfc3