### PR TITLE
feat: add 3D tech logo showcase

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -9,6 +9,9 @@ import { SocialIconButton } from '@/components/ui/social-icon-button';
 const ModelHero = dynamic(() => import('@/components/ModelHero'), {
   ssr: false,
 });
+const TechLogos3D = dynamic(() => import('@/components/TechLogos3D'), {
+  ssr: false,
+});
 
 export default function Hero() {
   const prefersReduceMotion = useReducedMotion();
@@ -38,6 +41,8 @@ export default function Hero() {
               Développeur&nbsp;Full-Stack
             </p>
           </div>
+
+          <TechLogos3D />
 
           <p className="hidden max-w-[28ch] text-sm text-gray-300 sm:block sm:max-w-md sm:text-base">
             Conception et développement d&apos;applications web modernes,

--- a/components/TechLogos3D.tsx
+++ b/components/TechLogos3D.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, useGLTF } from '@react-three/drei';
+
+type LogoProps = {
+  url: string;
+  position: [number, number, number];
+};
+
+function Logo({ url, position }: LogoProps) {
+  const { scene } = useGLTF(url);
+  return <primitive object={scene} position={position} />;
+}
+
+export default function TechLogos3D() {
+  return (
+    <div className="h-32 w-full">
+      <Canvas camera={{ position: [0, 0, 5] }}>
+        <ambientLight />
+        <directionalLight position={[2, 2, 5]} />
+        <Logo url="/models/react.gltf" position={[-1.5, 0, 0]} />
+        <Logo url="/models/node.gltf" position={[1.5, 0, 0]} />
+        <OrbitControls enableZoom={false} />
+      </Canvas>
+    </div>
+  );
+}
+
+useGLTF.preload('/models/react.gltf');
+useGLTF.preload('/models/node.gltf');

--- a/public/models/node.gltf
+++ b/public/models/node.gltf
@@ -1,0 +1,6 @@
+{
+  "asset": { "version": "2.0", "generator": "placeholder" },
+  "scene": 0,
+  "scenes": [ { "nodes": [] } ],
+  "extras": { "note": "Placeholder model for Node.js logo" }
+}

--- a/public/models/react.gltf
+++ b/public/models/react.gltf
@@ -1,0 +1,6 @@
+{
+  "asset": { "version": "2.0", "generator": "placeholder" },
+  "scene": 0,
+  "scenes": [ { "nodes": [] } ],
+  "extras": { "note": "Placeholder model for React logo" }
+}


### PR DESCRIPTION
## Summary
- add placeholder GLTF models for React and Node logos
- create TechLogos3D component to display models in a Three.js Canvas
- render TechLogos3D beneath the hero tagline

## Testing
- `bun run lint`
- `bun run test`
- `bun run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6895a2251f9883278d30bb73ff1ebea6