### PR TITLE
Improve SEO and highlight AI direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Victor Lenain – Portfolio Dev Web & DevOps
 
-> **Elevator-pitch :** je conçois des applications web modernes (Next 15 / R3F)
-> et j’automatise leur déploiement cloud. Démo 👉 <https://victorlenain.fr>
+> **Elevator-pitch :** développeur web full‑stack curieux, calme et raisonné,
+> je conçois des applications web modernes (Next 15 / R3F) intégrant des
+> solutions d'intelligence artificielle et j’automatise leur déploiement
+> cloud. Démo 👉 <https://victorlenain.fr>
 
 ![screencast](docs/assets/screen.gif)
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,7 +30,8 @@ export const metadata = {
     default: 'Victor Lenain | Développeur Full-Stack JavaScript & Expert Next.js',
     template: '%s | Victor Lenain'
   },
-  description: 'Développeur Full-Stack JavaScript spécialisé en Next.js 15, React 19 et DevOps. Création d\'applications web modernes et performantes avec intelligence artificielle intégrée.',
+  description:
+    "Développeur Full-Stack JavaScript curieux et réfléchi, spécialisé en Next.js 15, React 19 et DevOps. Création d'applications web modernes et performantes avec intégration d'intelligence artificielle.",
   keywords: [
     'développeur full-stack',
     'JavaScript',
@@ -38,7 +39,10 @@ export const metadata = {
     'React 19',
     'TypeScript',
     'DevOps',
-    'Intelligence artificielle',
+    'Intégration IA',
+    'curieux',
+    'calme',
+    'raisonné',
     'Développement web',
     'Applications modernes',
     'Portfolio',
@@ -64,7 +68,8 @@ export const metadata = {
     url: 'https://victorlenain.fr',
     siteName: 'Victor Lenain - Portfolio',
     title: 'Victor Lenain | Développeur Full-Stack JavaScript & Expert Next.js',
-    description: 'Développeur Full-Stack JavaScript spécialisé en Next.js 15, React 19 et DevOps. Création d\'applications web modernes et performantes.',
+    description:
+      "Développeur Full-Stack JavaScript curieux et réfléchi, expert en Next.js 15 et React 19, créant des applications web modernes avec intégration d'intelligence artificielle.",
     images: [
       {
         url: '/logo.png',
@@ -78,7 +83,8 @@ export const metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Victor Lenain | Développeur Full-Stack JavaScript',
-    description: 'Spécialisé en Next.js 15, React 19 et DevOps. Créateur d\'applications web modernes.',
+    description:
+      "Spécialisé en Next.js 15, React 19 et DevOps. Développeur curieux et calme, tourné vers l'intégration d'intelligence artificielle.",
     images: ['/logo.png'],
     creator: '@victor_lenain',
     site: '@victor_lenain',

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -7,25 +7,23 @@ export default function About() {
         À&nbsp;propos
       </h2>
 
-      <p className="max-w-xl leading-relaxed text-gray-300">
-        Développeur&nbsp;full-stack&nbsp;JavaScript diplômé du&nbsp;
-        <span className="font-semibold text-indigo-400">
-          Wagon
-        </span>{' '}
-        et d&apos;&nbsp;
-        <span className="font-semibold text-indigo-400">OpenClassrooms</span>,
-        avec&nbsp;
-        <span className="font-semibold text-indigo-400">
-          3 années d&apos;expérience
-        </span>{' '}
-        en développement web. Spécialisé dans les technologies modernes
-        et la création de solutions innovantes, je développe continuellement
-        mes compétences à travers des&nbsp;
-        <span className="font-semibold text-indigo-400">
-          projets open-source
-        </span>
-        .
-      </p>
+        <p className="max-w-xl leading-relaxed text-gray-300">
+          Développeur&nbsp;full-stack&nbsp;JavaScript curieux et discret,
+          diplômé du&nbsp;
+          <span className="font-semibold text-indigo-400">Wagon</span> et
+          d&apos;&nbsp;
+          <span className="font-semibold text-indigo-400">OpenClassrooms</span>,
+          avec&nbsp;
+          <span className="font-semibold text-indigo-400">
+            3 années d&apos;expérience
+          </span>{' '}
+          en développement web. Calme et raisonné, je me spécialise dans les
+          technologies modernes et l&apos;intégration de solutions
+          d&apos;intelligence artificielle, tout en développant continuellement mes
+          compétences à travers des&nbsp;
+          <span className="font-semibold text-indigo-400">projets open-source</span>
+          .
+        </p>
 
       <ul className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
         {(

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -32,18 +32,19 @@ export default function Hero() {
             Victor&nbsp;Lenain
           </h1>
 
-          <div className="mb-3 flex items-center gap-3 sm:justify-center">
-            <span className="h-1 w-8 rounded-full bg-gradient-to-r from-[#6bb4d8] via-[#4288b7] to-[#2d5e81]" />
-            <p className="text-sm font-medium uppercase tracking-wide text-indigo-200 sm:text-base">
-              Développeur&nbsp;Full-Stack
-            </p>
-          </div>
+            <div className="mb-3 flex items-center gap-3 sm:justify-center">
+              <span className="h-1 w-8 rounded-full bg-gradient-to-r from-[#6bb4d8] via-[#4288b7] to-[#2d5e81]" />
+              <p className="text-sm font-medium uppercase tracking-wide text-indigo-200 sm:text-base">
+                Développeur&nbsp;Full-Stack curieux&nbsp;&amp;&nbsp;raisonné
+              </p>
+            </div>
 
-          <p className="hidden max-w-[28ch] text-sm text-gray-300 sm:block sm:max-w-md sm:text-base">
-            Conception et développement d&apos;applications web modernes,
-            d&apos;expériences&nbsp;3D et de solutions&nbsp;IA.
-          </p>
-        </motion.header>
+            <p className="hidden max-w-[28ch] text-sm text-gray-300 sm:block sm:max-w-md sm:text-base">
+              Curieux de tout mais d&apos;une nature calme, je conçois des
+              applications web modernes, des expériences&nbsp;3D et des
+              solutions&nbsp;d&apos;intelligence artificielle.
+            </p>
+          </motion.header>
 
         {/* Visuel 3D */}
         <motion.div


### PR DESCRIPTION
## Summary
- refine site metadata with AI-focused keywords and personality traits
- update hero and about sections to stress curiosity and calm approach
- adjust README elevator pitch to mention AI integration

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68959de7fb4083279a1cf2d70637519a