### PR TITLE
refactor: align LinkedIn URL + wording with freelance-brand KB

### DIFF
--- a/app/components/BlogPostJsonLd.tsx
+++ b/app/components/BlogPostJsonLd.tsx
@@ -39,7 +39,7 @@ export default function BlogPostJsonLd({
       url: BASE_URL,
       jobTitle: 'Développeur full-stack · Intégration IA',
       sameAs: [
-        'https://www.linkedin.com/in/victor-lenain/',
+        'https://www.linkedin.com/in/victorlenain/',
         'https://github.com/VictorNain26',
         'https://www.malt.fr/profile/victorlenain',
       ],

--- a/app/metadata-config.ts
+++ b/app/metadata-config.ts
@@ -12,7 +12,7 @@ export const personJsonLd = {
   url: 'https://victorlenain.fr',
   image: 'https://victorlenain.fr/og-image.png',
   sameAs: [
-    'https://www.linkedin.com/in/victor-lenain/',
+    'https://www.linkedin.com/in/victorlenain/',
     'https://github.com/VictorNain26',
     'https://www.malt.fr/profile/victorlenain',
   ],
@@ -253,7 +253,7 @@ export const professionalServiceJsonLd = {
           '@type': 'Service',
           name: 'Automatisations LLM sur mesure',
           description:
-            "Pipelines LLM en production : génération de contenu, classification, extraction structurée, scoring. Coûts tokens maîtrisés.",
+            "Pipelines LLM en production : génération de contenu, classification, extraction structurée, scoring. Suivi des coûts tokens, eval dès le démarrage.",
         },
       },
       {

--- a/components/ArticleLayout.tsx
+++ b/components/ArticleLayout.tsx
@@ -96,14 +96,14 @@ export default function ArticleLayout({
             <p className="font-semibold text-white">Victor Lenain</p>
             <p className="mt-0.5 text-sm leading-relaxed text-gray-400">
               Développeur full-stack freelance · Intégration IA · Paris.
-              Next.js, TypeScript, Claude, OpenAI.
+              Je greffe la couche IA sur votre stack web existante.
             </p>
           </div>
         </div>
         <div className="mt-5 flex flex-wrap gap-3">
           <a
             className="inline-flex items-center gap-1.5 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-4 py-1.5 text-sm font-medium text-indigo-400 transition-colors hover:bg-indigo-500/20"
-            href="https://www.linkedin.com/in/victor-lenain/"
+            href="https://www.linkedin.com/in/victorlenain/"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,7 +4,7 @@ import { SiMalt } from 'react-icons/si';
 
 const socials = [
   { href: 'https://github.com/VictorNain26', icon: FaGithub, label: 'GitHub' },
-  { href: 'https://www.linkedin.com/in/victor-lenain/', icon: FaLinkedin, label: 'LinkedIn' },
+  { href: 'https://www.linkedin.com/in/victorlenain/', icon: FaLinkedin, label: 'LinkedIn' },
   { href: 'https://www.malt.fr/profile/victorlenain', icon: SiMalt, label: 'Malt' },
   {
     href: 'https://wa.me/33664422529?text=Bonjour%20Victor%2C%20je%20souhaiterais%20discuter%20d%27un%20projet%20avec%20vous',

--- a/components/HeaderBar.tsx
+++ b/components/HeaderBar.tsx
@@ -23,7 +23,7 @@ const NAV_SECTIONS = [
 const socials = [
   { href: 'https://github.com/victornain26', icon: FaGithub, label: 'GitHub' },
   {
-    href: 'https://www.linkedin.com/in/victor-lenain/',
+    href: 'https://www.linkedin.com/in/victorlenain/',
     icon: FaLinkedin,
     label: 'LinkedIn',
   },

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -60,11 +60,11 @@ export default function Hero() {
           {...fadeUp(0.1)}
           className="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-gray-400 text-balance sm:mt-6 sm:text-xl"
         >
-          Développeur full-stack freelance à Paris,{' '}
+          Développeur full-stack freelance à Paris.{' '}
           <span className="text-gray-300">
-            spécialisé dans l&apos;intégration d&apos;IA
-          </span>{' '}
-          (agents, RAG, automatisations LLM) dans des produits web et SaaS.
+            Je greffe la couche IA sur votre stack web existante
+          </span>
+          , sans refonte. Vos POCs deviennent des systèmes qui tiennent.
         </motion.p>
 
         {/* CTAs */}
@@ -139,11 +139,11 @@ export default function Hero() {
           </span>
           <span className="flex items-center gap-1.5">
             <span aria-hidden="true" className="h-1 w-1 rounded-full bg-indigo-500/60" />
-            Next.js, TypeScript, Node.js
+            Stack Next.js / Node.js / PostgreSQL
           </span>
           <span className="flex items-center gap-1.5">
             <span aria-hidden="true" className="h-1 w-1 rounded-full bg-indigo-500/60" />
-            Claude, OpenAI, RAG, agents
+            Eval dès le démarrage
           </span>
         </motion.div>
       </div>

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -24,13 +24,13 @@ const services = [
     title: 'Automatisations LLM sur mesure',
     description:
       'Plutôt que d\'empiler des outils no-code, je code des automatisations sur mesure quand le ROI est là. Génération de contenu, classification, extraction structurée, scoring. Et un script de 50 lignes si c\'est le bon outil.',
-    results: ['Pipelines LLM en prod', 'Coûts tokens maîtrisés', 'Eval avant déploiement'],
+    results: ['Pipelines LLM en production', 'Suivi coûts tokens', 'Eval dès le démarrage'],
   },
   {
     icon: Rocket,
     title: 'Applications web sur mesure',
     description:
-      'Sites vitrines, applications métier, plateformes SaaS. Stack Next.js / TypeScript / Node.js. Je porte le projet du POC au déployé, IA embarquée si elle apporte de la valeur réelle.',
+      'Sites vitrines, applications métier, plateformes SaaS. Stack Next.js / TypeScript / Node.js. Je prends le projet du POC au déploiement, IA embarquée si elle apporte de la valeur réelle.',
     results: ['Next.js, TypeScript', 'API Node.js, PostgreSQL', 'Vercel ou Docker'],
   },
   {

--- a/content/posts/2025-01-12-developpeur-freelance-paris.mdx
+++ b/content/posts/2025-01-12-developpeur-freelance-paris.mdx
@@ -102,4 +102,4 @@ Je propose un premier échange gratuit pour comprendre votre contexte et vous pr
 
 - Découvrez mes [réalisations](/#projets) sur le portfolio
 - Consultez mes [services](/#services) en détail
-- Retrouvez-moi sur [GitHub](https://github.com/victornain26) et [LinkedIn](https://www.linkedin.com/in/victor-lenain/)
+- Retrouvez-moi sur [GitHub](https://github.com/victornain26) et [LinkedIn](https://www.linkedin.com/in/victorlenain/)

--- a/content/posts/2026-02-26-communication-cle-projet-web-reussi.mdx
+++ b/content/posts/2026-02-26-communication-cle-projet-web-reussi.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Pourquoi la communication fait souvent la différence dans un projet web"
-summary: "En 2 ans d'agence, j'ai remarqué que les projets les mieux réussis n'étaient pas forcément ceux avec les meilleurs développeurs — mais ceux où la communication était la plus fluide."
+summary: "En 2 ans d'agence, j'ai remarqué que les projets les mieux réussis n'étaient pas forcément ceux avec les meilleurs développeurs, mais ceux où la communication était la plus fluide."
 publishedAt: '2026-02-26'
 tags:
   - Freelance

--- a/content/posts/2026-03-17-erreurs-externalisation-developpement-web.mdx
+++ b/content/posts/2026-03-17-erreurs-externalisation-developpement-web.mdx
@@ -1,6 +1,6 @@
 ---
 title: "5 erreurs courantes quand on externalise le développement web"
-summary: "Externaliser son développement web, c'est souvent la bonne décision. Mais mal géré, ça peut vite devenir un cauchemar. Voici les erreurs que je vois le plus souvent — et comment les éviter."
+summary: "Externaliser son développement web, c'est souvent la bonne décision. Mais mal géré, ça peut vite devenir un cauchemar. Voici les erreurs que je vois le plus souvent, et comment les éviter."
 publishedAt: '2026-03-17'
 tags:
   - Freelance

--- a/content/posts/2026-03-24-workflow-claude-code-freelance.mdx
+++ b/content/posts/2026-03-24-workflow-claude-code-freelance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Mon workflow avec Claude Code : comment je livre plus vite en 2026"
-summary: "84% des développeurs utilisent l'IA au quotidien. Voici comment j'intègre Claude Code dans mon workflow freelance — et pourquoi c'est un avantage pour mes clients."
+summary: "84% des développeurs utilisent l'IA au quotidien. Voici comment j'intègre Claude Code dans mon workflow freelance, et pourquoi c'est un avantage pour mes clients."
 publishedAt: '2026-03-24'
 tags:
   - Intelligence Artificielle

--- a/content/posts/2026-03-31-nextjs-16-turbopack-retour-experience.mdx
+++ b/content/posts/2026-03-31-nextjs-16-turbopack-retour-experience.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Next.js 16 + Turbopack : retour d'expérience sur un vrai projet"
-summary: "Turbopack est enfin stable. Après plusieurs mois d'utilisation sur des projets clients, voici ce qui change vraiment — et ce qui ne change pas."
+summary: "Turbopack est enfin stable. Après plusieurs mois d'utilisation sur des projets clients, voici ce qui change vraiment, et ce qui ne change pas."
 publishedAt: '2026-03-31'
 tags:
   - Next.js

--- a/content/posts/2026-04-02-bilan-deux-ans-freelance-cdi.mdx
+++ b/content/posts/2026-04-02-bilan-deux-ans-freelance-cdi.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CDI ou freelance dev en 2026 : mon bilan après 2 ans d'indépendance"
-summary: "En avril 2024, j'ai quitté mon CDI pour devenir freelance. Deux ans plus tard, voici ce que j'ai appris — en toute honnêteté."
+summary: "En avril 2024, j'ai quitté mon CDI pour devenir freelance. Deux ans plus tard, voici ce que j'ai appris, en toute honnêteté."
 publishedAt: '2026-04-02'
 tags:
   - Freelance

--- a/content/posts/2026-04-09-react-server-components-production.mdx
+++ b/content/posts/2026-04-09-react-server-components-production.mdx
@@ -1,6 +1,6 @@
 ---
 title: "React Server Components en production : ce que j'ai appris"
-summary: "Les Server Components promettent moins de JavaScript côté client et de meilleures performances. Après plusieurs projets en production, voici ce qui fonctionne — et les pièges à éviter."
+summary: "Les Server Components promettent moins de JavaScript côté client et de meilleures performances. Après plusieurs projets en production, voici ce qui fonctionne, et les pièges à éviter."
 publishedAt: '2026-04-09'
 tags:
   - React

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -17,7 +17,7 @@
 
 - [Agents IA et assistants conversationnels](https://victorlenain.fr/#services) : conception et déploiement d'agents Claude / OpenAI (tri de mails, qualification de leads, exécution d'actions). Stack Claude Agent SDK ou LangChain
 - [RAG et recherche sur documents](https://victorlenain.fr/#services) : ingestion, embeddings, recherche sémantique, réponses sourcées. pgvector pour rester sur PostgreSQL, Qdrant si volume
-- [Automatisations LLM sur mesure](https://victorlenain.fr/#services) : pipelines LLM en production, classification, extraction structurée, génération de contenu. Coûts tokens maîtrisés, eval avant déploiement
+- [Automatisations LLM sur mesure](https://victorlenain.fr/#services) : pipelines LLM en production, classification, extraction structurée, génération de contenu. Suivi des coûts tokens, eval dès le démarrage
 - [Applications web sur mesure](https://victorlenain.fr/#services) : sites vitrines, applications métier, plateformes SaaS. Stack Next.js / TypeScript / Node.js
 - [Refonte et interventions ponctuelles](https://victorlenain.fr/#services) : refonte visuelle, migration technique, fix urgent, ajout de fonctionnalité. À partir d'une demi-journée
 - [Conseil et audit IA](https://victorlenain.fr/#services) : cadrage POC, choix de stack et coûts, audit d'un projet existant
@@ -56,7 +56,7 @@
 - Site : https://victorlenain.fr
 - Email : victor.lenain26@gmail.com
 - Réserver un appel : https://cal.com/victor-lenain-ejsjfb/echange-decouverte
-- LinkedIn : https://www.linkedin.com/in/victor-lenain/
+- LinkedIn : https://www.linkedin.com/in/victorlenain/
 - Malt : https://www.malt.fr/profile/victorlenain
 - GitHub : https://github.com/VictorNain26
 - WhatsApp : https://wa.me/33664422529


### PR DESCRIPTION
## Summary
- Update LinkedIn handle from `/in/victor-lenain` to canonical `/in/victorlenain` across 7 surfaces (header, footer, article bio, metadata, JSON-LD, llms.txt, landing post)
- Sweep wording anti-patterns flagged by the `freelance-brand` KB (`voice/voice-profile.md`, `positioning/branding.md`):
  - Hero subtitle + credibility chips: drop IA tech-listing in surface, reformulate around brand promises (POC->système, greffe sur stack existante, eval dès le démarrage)
  - Services results: `Pipelines LLM en prod` -> `en production`, `Coûts tokens maîtrisés` -> `Suivi coûts tokens`, `du POC au déployé` -> `au déploiement`, `Eval avant déploiement` -> `Eval dès le démarrage`
  - ArticleLayout bio: tech-listing -> brand value prop
  - `metadata-config.ts` + `llms.txt`: drop `Coûts tokens maîtrisés`
- 6 blog summaries: em-dash replaced by comma (voice-profile §2 anti-pattern)

## Cross-repo sync
The KB in `freelance-brand` (separate repo, `C:\Users\ordiv\Desktop\freelance-brand`) was also updated to reflect the validated site wording:
- `positioning/branding.md` §Hero site: H1 (`Votre projet web, IA intégrée`) and subtitle backported from the site (validated in commit bf507ff for above-the-fold UX)
- Dated synchro note added (2026-05-22) distinguishing the site format (paragraph) from the short Malt/LinkedIn format (bullets)

## Not in scope
- `2025-01-12-developpeur-freelance-paris.mdx` body — old landing copy with marketing tone, kept intact for SEO (canonical landing for "développeur freelance Paris"). Rewrite worth its own PR if desired.
- Other blog posts: grep for "Pas X. Y." patterns returned legitimate natural speech (matches voice profile §1.3 "Marques d'oralité"), not the polished marketing pattern banned by §2.

## Test plan
- [x] `bun run type-check` passes
- [x] `bun run lint` passes
- [ ] Visual check: Hero renders new subtitle + credibility chips correctly
- [ ] Visual check: ArticleLayout bio on any blog post
- [ ] Click LinkedIn icon in header/footer/article → lands on `/in/victorlenain`
- [ ] Blog list (`/blog`) shows summaries without em-dash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Standardized LinkedIn profile URL formatting across site components.
  * Refined service descriptions with updated messaging for LLM automation offerings.
  * Updated hero section subtitle and credibility bar text with new French phrasing.
  * Standardized typography and punctuation in blog post metadata for consistency.
  * Enhanced professional contact information in metadata and public resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VictorNain26/portfolio_site/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->