### PR TITLE
refactor: POC -> prototype dans le wording client-facing

### DIFF
--- a/app/metadata-config.ts
+++ b/app/metadata-config.ts
@@ -280,7 +280,7 @@ export const professionalServiceJsonLd = {
           '@type': 'Service',
           name: 'Conseil et audit IA',
           description:
-            "Cadrage POC, choix de stack et coûts, audit d'un projet existant. Arbitrage entre script classique, no-code et intégration LLM.",
+            "Cadrage prototype, choix de stack et coûts, audit d'un projet existant. Arbitrage entre script classique, no-code et intégration LLM.",
         },
       },
     ],

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -64,7 +64,7 @@ export default function Hero() {
           <span className="text-gray-300">
             Je greffe la couche IA sur votre stack web existante
           </span>
-          , sans refonte. Vos POCs deviennent des systèmes qui tiennent.
+          , sans refonte. Vos prototypes deviennent des systèmes qui tiennent.
         </motion.p>
 
         {/* CTAs */}

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -30,7 +30,7 @@ const services = [
     icon: Rocket,
     title: 'Applications web sur mesure',
     description:
-      'Sites vitrines, applications métier, plateformes SaaS. Stack Next.js / TypeScript / Node.js. Je prends le projet du POC au déploiement, IA embarquée si elle apporte de la valeur réelle.',
+      'Sites vitrines, applications métier, plateformes SaaS. Stack Next.js / TypeScript / Node.js. Je prends le projet du prototype au déploiement, IA embarquée si elle apporte de la valeur réelle.',
     results: ['Next.js, TypeScript', 'API Node.js, PostgreSQL', 'Vercel ou Docker'],
   },
   {
@@ -44,8 +44,8 @@ const services = [
     icon: Sparkles,
     title: 'Conseil et audit IA',
     description:
-      'Avant de coder, on regarde si l\'IA est vraiment le bon outil. Je vous aide à arbitrer entre script classique, automatisation no-code et intégration LLM, et à cadrer un POC sérieux.',
-    results: ['Cadrage POC', 'Choix de stack et coûts', 'Audit d\'un projet existant'],
+      'Avant de coder, on regarde si l\'IA est vraiment le bon outil. Je vous aide à arbitrer entre script classique, automatisation no-code et intégration LLM, et à cadrer un prototype sérieux.',
+    results: ['Cadrage prototype', 'Choix de stack et coûts', 'Audit d\'un projet existant'],
   },
 ];
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -20,7 +20,7 @@
 - [Automatisations LLM sur mesure](https://victorlenain.fr/#services) : pipelines LLM en production, classification, extraction structurée, génération de contenu. Suivi des coûts tokens, eval dès le démarrage
 - [Applications web sur mesure](https://victorlenain.fr/#services) : sites vitrines, applications métier, plateformes SaaS. Stack Next.js / TypeScript / Node.js
 - [Refonte et interventions ponctuelles](https://victorlenain.fr/#services) : refonte visuelle, migration technique, fix urgent, ajout de fonctionnalité. À partir d'une demi-journée
-- [Conseil et audit IA](https://victorlenain.fr/#services) : cadrage POC, choix de stack et coûts, audit d'un projet existant
+- [Conseil et audit IA](https://victorlenain.fr/#services) : cadrage prototype, choix de stack et coûts, audit d'un projet existant
 
 ## Stack technique
 


### PR DESCRIPTION
## Summary
Aligne le wording du site sur `freelance-brand/positioning/branding.md` qui utilise désormais `prototype` partout dans le client-facing (§Hero site, §Value proposition, §Promesse client #1). `POC` est un terme jargon tech trop niche pour un sous-titre Hero ou une description de service publique.

## Surfaces touchées (4 fichiers, 6 occurrences)
- `components/Hero.tsx` — sous-titre : `Vos POCs deviennent…` → `Vos prototypes deviennent…`
- `components/Services.tsx` — Applications web : `du POC au déploiement` → `du prototype au déploiement`
- `components/Services.tsx` — Conseil et audit : `cadrer un POC sérieux` → `cadrer un prototype sérieux` + chip result `Cadrage POC` → `Cadrage prototype`
- `app/metadata-config.ts` — JSON-LD ProfessionalService offer "Conseil et audit IA" : idem
- `public/llms.txt` — catalogue services : idem

## Hors scope
- `POC` conservé dans la KB côté sections internes (§Cible client mentionne "POC LLM dans un coin", §Anti-positions cite "POC d'IA en 2 semaines") — contexte tech légitime
- Articles de blog techniques laissés intacts (POC y est employé dans son sens technique)

## Test plan
- [x] `bun run type-check` passes
- [x] `bun run lint` passes
- [ ] Visual check Hero : nouveau sous-titre lisible
- [ ] Visual check Services : card "Conseil et audit IA" chip "Cadrage prototype"