### PR TITLE
test: cover core logic and fix the (silently broken) coverage gate

### DIFF
--- a/app/__tests__/sitemap.test.ts
+++ b/app/__tests__/sitemap.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * The sitemap must list static pages + all services + only *published* blog
+ * posts (future-dated posts are scheduled and must stay out). Featured
+ * services get a higher priority than secondary ones. We mock the two content
+ * sources so the test is deterministic regardless of real content.
+ */
+
+vi.mock('content-collections', () => ({
+  allPosts: [
+    { slug: 'past-post', publishedAt: '2025-01-01' },
+    { slug: 'future-post', publishedAt: '2099-01-01' },
+  ],
+}));
+
+vi.mock('../services/content', () => ({
+  services: [
+    { slug: 'featured-service', tier: 'featured' },
+    { slug: 'secondary-service', tier: 'secondary' },
+  ],
+}));
+
+import sitemap from '../sitemap';
+
+const BASE = 'https://victorlenain.fr';
+
+describe('sitemap', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-29T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('includes the core static pages', () => {
+    const urls = sitemap().map(e => e.url);
+    expect(urls).toContain(BASE);
+    expect(urls).toContain(`${BASE}/blog`);
+    expect(urls).toContain(`${BASE}/services`);
+  });
+
+  it('includes a URL for every service', () => {
+    const urls = sitemap().map(e => e.url);
+    expect(urls).toContain(`${BASE}/services/featured-service`);
+    expect(urls).toContain(`${BASE}/services/secondary-service`);
+  });
+
+  it('gives featured services a higher priority than secondary ones', () => {
+    const entries = sitemap();
+    const featured = entries.find(e => e.url.endsWith('/featured-service'));
+    const secondary = entries.find(e => e.url.endsWith('/secondary-service'));
+    expect(featured?.priority).toBe(0.85);
+    expect(secondary?.priority).toBe(0.7);
+  });
+
+  it('lists published blog posts but excludes future-dated ones', () => {
+    const urls = sitemap().map(e => e.url);
+    expect(urls).toContain(`${BASE}/blog/past-post`);
+    expect(urls).not.toContain(`${BASE}/blog/future-post`);
+  });
+
+  it('stamps blog entries with the post publish date as lastModified', () => {
+    const entry = sitemap().find(e => e.url.endsWith('/blog/past-post'));
+    expect(entry?.lastModified).toEqual(new Date('2025-01-01'));
+  });
+});

--- a/app/services/__tests__/content.test.ts
+++ b/app/services/__tests__/content.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { services, getService, ACCENT_CLASSES, type ServiceSlug } from '../content';
+
+/**
+ * `services` is hand-authored content that feeds the /services routes, the
+ * sitemap, and the nav. A typo in a slug, accent, or tier silently breaks a
+ * page or the build. These tests act as a schema guard for that content.
+ */
+
+const VALID_ACCENTS = ['indigo', 'violet', 'cyan', 'sky', 'amber', 'emerald'] as const;
+const VALID_TIERS = ['featured', 'secondary'] as const;
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+describe('services content', () => {
+  it('is non-empty', () => {
+    expect(services.length).toBeGreaterThan(0);
+  });
+
+  it('has unique slugs', () => {
+    const slugs = services.map(s => s.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it.each(services)('"$slug" has a valid, URL-safe slug', service => {
+    expect(service.slug).toMatch(SLUG_RE);
+  });
+
+  it.each(services)('"$slug" uses a known accent and tier', service => {
+    expect(VALID_ACCENTS).toContain(service.accent);
+    expect(VALID_TIERS).toContain(service.tier);
+  });
+
+  it.each(services)('"$slug" has the required copy fields populated', service => {
+    expect(service.shortTitle.length).toBeGreaterThan(0);
+    expect(service.title.length).toBeGreaterThan(0);
+    expect(service.tagline.length).toBeGreaterThan(0);
+    expect(service.ctaLabel.length).toBeGreaterThan(0);
+    expect(service.highlights.length).toBeGreaterThan(0);
+    expect(service.problem.length).toBeGreaterThan(0);
+    expect(service.approach.length).toBeGreaterThan(0);
+    expect(service.stack.length).toBeGreaterThan(0);
+    expect(service.useCases.length).toBeGreaterThan(0);
+    expect(service.faq.length).toBeGreaterThan(0);
+  });
+
+  it('has a non-empty meta description within a reasonable upper bound', () => {
+    // Google typically truncates around ~160 chars; we guard against empty or
+    // runaway descriptions rather than enforcing an exact SEO cutoff.
+    for (const service of services) {
+      expect(service.metaDescription.length).toBeGreaterThan(0);
+      expect(
+        service.metaDescription.length,
+        `${service.slug} metaDescription is unusually long`,
+      ).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it('has at least one featured service', () => {
+    expect(services.some(s => s.tier === 'featured')).toBe(true);
+  });
+});
+
+describe('getService', () => {
+  it('returns the matching service for a known slug', () => {
+    const slug = services[0]?.slug as ServiceSlug;
+    const found = getService(slug);
+    expect(found).toBeDefined();
+    expect(found?.slug).toBe(slug);
+  });
+
+  it('returns undefined for an unknown slug', () => {
+    expect(getService('does-not-exist')).toBeUndefined();
+  });
+});
+
+describe('ACCENT_CLASSES', () => {
+  it('defines a class set for every accent used by a service', () => {
+    for (const service of services) {
+      expect(ACCENT_CLASSES[service.accent]).toBeDefined();
+      expect(ACCENT_CLASSES[service.accent].text.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/lib/__tests__/github.test.ts
+++ b/lib/__tests__/github.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getGitHubProjects, getTechnologyColor } from '../github';
+
+/**
+ * `lib/github.ts` drives the Projects section. It fetches repos, keeps only
+ * those tagged `demo`, enriches them with languages, and degrades silently to
+ * an empty list on any failure. These tests pin that contract by mocking
+ * `fetch`.
+ */
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const baseRepo = {
+  id: 1,
+  name: 'demo-app',
+  full_name: 'victornain26/demo-app',
+  description: 'A demo app',
+  html_url: 'https://github.com/victornain26/demo-app',
+  homepage: 'https://demo.example.com',
+  topics: ['demo'],
+  language: 'TypeScript',
+  stargazers_count: 12,
+  updated_at: '2025-05-01T00:00:00Z',
+  created_at: '2025-01-01T00:00:00Z',
+  languages_url: 'https://api.github.com/repos/victornain26/demo-app/languages',
+};
+
+describe('getGitHubProjects', () => {
+  let fetchMock: FetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns only repos tagged "demo" and maps them to Projects', async () => {
+    fetchMock
+      // repos list
+      .mockResolvedValueOnce(
+        jsonResponse([
+          baseRepo,
+          { ...baseRepo, id: 2, name: 'not-a-demo', topics: ['library'] },
+        ]),
+      )
+      // languages for the demo repo
+      .mockResolvedValueOnce(jsonResponse({ TypeScript: 1000, CSS: 200 }));
+
+    const projects = await getGitHubProjects();
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toMatchObject({
+      id: 1,
+      name: 'demo-app',
+      description: 'A demo app',
+      demoUrl: 'https://demo.example.com',
+      repoUrl: 'https://github.com/victornain26/demo-app',
+      technologies: ['TypeScript', 'CSS'],
+      stars: 12,
+    });
+  });
+
+  it('excludes repos whose name contains a dot (e.g. username.github.io)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([{ ...baseRepo, name: 'victornain26.github.io' }]),
+    );
+
+    const projects = await getGitHubProjects();
+    expect(projects).toEqual([]);
+  });
+
+  it('falls back to a default description and null demoUrl when fields are missing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([{ ...baseRepo, description: null, homepage: null }]),
+      )
+      .mockResolvedValueOnce(jsonResponse({}));
+
+    const [project] = await getGitHubProjects();
+    expect(project?.description).toBe('Aucune description disponible');
+    expect(project?.demoUrl).toBeNull();
+    expect(project?.technologies).toEqual([]);
+  });
+
+  it('caps technologies at the top 5 languages, sorted by usage', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([baseRepo])).mockResolvedValueOnce(
+      jsonResponse({
+        Go: 10,
+        TypeScript: 100,
+        CSS: 50,
+        HTML: 5,
+        Python: 80,
+        Ruby: 1,
+      }),
+    );
+
+    const [project] = await getGitHubProjects();
+    expect(project?.technologies).toEqual(['TypeScript', 'Python', 'CSS', 'Go', 'HTML']);
+    expect(project?.technologies).toHaveLength(5);
+  });
+
+  it('sorts projects by most recently updated first', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { ...baseRepo, id: 1, name: 'older', updated_at: '2025-01-01T00:00:00Z' },
+          { ...baseRepo, id: 2, name: 'newer', updated_at: '2025-09-01T00:00:00Z' },
+        ]),
+      )
+      // languages calls for both repos
+      .mockResolvedValue(jsonResponse({ TypeScript: 1 }));
+
+    const projects = await getGitHubProjects();
+    expect(projects.map(p => p.name)).toEqual(['newer', 'older']);
+  });
+
+  it('returns [] when the repos request is not ok', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 403));
+    expect(await getGitHubProjects()).toEqual([]);
+  });
+
+  it('returns [] when fetch throws', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    expect(await getGitHubProjects()).toEqual([]);
+  });
+
+  it('yields empty technologies (not a crash) when the languages request fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse([baseRepo]))
+      .mockResolvedValueOnce(jsonResponse({}, false, 500));
+
+    const [project] = await getGitHubProjects();
+    expect(project?.technologies).toEqual([]);
+  });
+});
+
+describe('getTechnologyColor', () => {
+  it('returns the mapped color for a known technology', () => {
+    expect(getTechnologyColor('TypeScript')).toBe('#3178C6');
+    expect(getTechnologyColor('Python')).toBe('#3776AB');
+  });
+
+  it('returns the neutral fallback color for an unknown technology', () => {
+    expect(getTechnologyColor('COBOL')).toBe('#6B7280');
+    expect(getTechnologyColor('')).toBe('#6B7280');
+  });
+});

--- a/lib/__tests__/indexnow.test.ts
+++ b/lib/__tests__/indexnow.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { notifyIndexNow } from '../indexnow';
+
+/**
+ * `notifyIndexNow` pings the IndexNow endpoints for Bing/Yandex/etc. It must
+ * post the correct payload to both endpoints and never throw — a failing
+ * endpoint is logged, not propagated.
+ */
+
+describe('notifyIndexNow', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ status: 200 } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('posts to both the IndexNow and Bing endpoints', async () => {
+    await notifyIndexNow(['https://victorlenain.fr/blog/new-post']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const calledEndpoints = fetchMock.mock.calls.map(c => c[0]);
+    expect(calledEndpoints).toContain('https://api.indexnow.org/indexnow');
+    expect(calledEndpoints).toContain('https://www.bing.com/indexnow');
+  });
+
+  it('sends the expected JSON payload with the URL list', async () => {
+    const urls = ['https://victorlenain.fr/a', 'https://victorlenain.fr/b'];
+    await notifyIndexNow(urls);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      host: 'victorlenain.fr',
+      urlList: urls,
+    });
+    expect(body.key).toBeTruthy();
+    expect(body.keyLocation).toContain(body.key);
+  });
+
+  it('does not throw when an endpoint rejects', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ status: 200 } as Response)
+      .mockRejectedValueOnce(new Error('endpoint down'));
+
+    await expect(notifyIndexNow(['https://victorlenain.fr/x'])).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/test/stubs/content-collections.ts
+++ b/test/stubs/content-collections.ts
@@ -1,0 +1,7 @@
+/**
+ * Test stub for the `content-collections` virtual module, which is generated
+ * at build time (`.content-collections/generated`) and therefore absent during
+ * unit tests. Aliased in `vitest.config.ts`. Individual tests that need posts
+ * override this with `vi.mock('content-collections', ...)`.
+ */
+export const allPosts: unknown[] = [];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
+      // Report on the whole source tree, not just files a test happens to
+      // import. Without this, coverage % is computed over a handful of files
+      // and the thresholds below guard almost nothing.
+      all: true,
+      include: ['app/**', 'components/**', 'hooks/**', 'lib/**'],
       exclude: [
         'node_modules/',
         '.next/',
@@ -28,14 +33,25 @@ export default defineConfig({
         '*.d.ts',
         'coverage/',
         'public/',
+        'test/**',
+        '**/__tests__/**',
+        // Presentational/layout shells and static assets: no logic to unit test.
+        'app/**/layout.tsx',
+        'app/**/page.tsx',
+        'app/**/opengraph-image.tsx',
+        'app/**/icon*.{ts,tsx}',
+        'app/**/manifest.json',
+        'app/globals.css',
       ],
+      // Realistic floor that the current suite clears. Ratchet upward as more
+      // logic gets covered — do not lower it. NB: Vitest expects these keys at
+      // the top level of `thresholds`; nesting them under `global` (the old
+      // nyc/istanbul style) silently disables the gate.
       thresholds: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
+        branches: 14,
+        functions: 15,
+        lines: 17,
+        statements: 17,
       },
     },
 
@@ -67,6 +83,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './'),
+      // `content-collections` is generated at build time and absent in tests.
+      // Alias to a stub so modules importing it (e.g. sitemap) can be tested;
+      // tests that need real posts override it via `vi.mock`.
+      'content-collections': resolve(__dirname, './test/stubs/content-collections.ts'),
     },
   },
 


### PR DESCRIPTION
## Summary

Started as a coverage analysis and turned into a fix: **the previous coverage gate never enforced anything.**

- `bun run test:coverage` reported `100%` because v8 only measured the handful of files a test imported.
- The `80%` thresholds were nested under a `global` key — **not a valid Vitest 4 key** (it's interpreted as a glob matching nothing), so the gate was silently disabled.
- True baseline, once the whole tree is measured: **~18% statements / 15% branches**.

This PR makes coverage honest, makes the gate actually bite, and adds tests for the highest value-per-effort untested logic.

## Coverage config (`vitest.config.ts`)
- Enable `coverage.all` + an `include` glob so the whole `app`/`components`/`hooks`/`lib` tree is measured. Excludes presentational route/layout shells, OG images, and static assets (no logic to unit-test).
- Flatten the threshold keys to the top level of `thresholds` so Vitest 4 enforces them. Verified the gate now fails at an unmet threshold and passes at the floor.
- Set an honest floor (17% lines/statements, 15% functions, 14% branches) that the suite clears — **to be ratcheted upward, not lowered.**

## New tests (55 → 98 passing)
- **`lib/github.ts`** (→ 96%): `demo`-topic filtering, dotted-name exclusion (`*.github.io`), description/homepage fallbacks, top-5 language cap + sort, recency sorting, and both silent-failure paths (non-ok response, fetch throw, language fetch failure).
- **`lib/indexnow.ts`** (→ 100%): posts to both endpoints, correct payload shape, never throws when an endpoint rejects.
- **`app/services/content.ts`**: data-integrity guard — unique & URL-safe slugs, valid accents/tiers, required copy fields populated, ≥1 featured service — plus `getService` hit/miss.
- **`app/sitemap.ts`**: static + per-service URLs, featured (`0.85`) vs secondary (`0.7`) priority, exclusion of future-dated posts, `lastModified` stamping.
- Adds a `content-collections` test stub (the module is generated at build time and absent during tests), aliased in `vitest.config.ts`.

## Notes / follow-ups
- One content observation surfaced: `applications-web` has a 179-char `metaDescription` (Google truncates ~160). I did **not** change content; the test asserts a generous upper bound instead. Worth a copy edit separately.
- Next ratchet targets: interactive components with real behavior (`HeaderBar`, `BackToTop`, `FAQ`), the `useFadeOnView` hook, and the JSON-LD/SEO config.

## Checks
`bun run type-check`, `bun run lint`, and `bun run test` all pass (98 tests). Coverage gate enforces and passes.

https://claude.ai/code/session_0196kgEbL9zP3r5kstUd8VAU

---
_Generated by [Claude Code](https://claude.ai/code/session_0196kgEbL9zP3r5kstUd8VAU)_