### PR TITLE
fix(a11y): honor prefers-reduced-motion for programmatic scrolling

### DIFF
--- a/components/BackToTop.tsx
+++ b/components/BackToTop.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronUp } from 'lucide-react';
+import { getScrollBehavior } from '@/lib/utils';
 
 export default function BackToTop() {
   const pathname = usePathname();
@@ -58,17 +59,19 @@ export default function BackToTop() {
   const scrollToTop = (e: React.MouseEvent) => {
     e.preventDefault();
 
+    const behavior = getScrollBehavior();
+
     const hero = document.getElementById('accueil');
     if (hero) {
-      hero.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      hero.scrollIntoView({ behavior, block: 'start' });
       return;
     }
 
     const viewport = document.getElementById('scroll-viewport');
     if (viewport) {
-      viewport.scrollTo({ top: 0, behavior: 'smooth' });
+      viewport.scrollTo({ top: 0, behavior });
     } else {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
+      window.scrollTo({ top: 0, behavior });
     }
   };
 

--- a/components/HeaderBar.tsx
+++ b/components/HeaderBar.tsx
@@ -8,6 +8,7 @@ import { usePathname } from 'next/navigation';
 import { Calendar, Menu, X } from 'lucide-react';
 import { GitHubIcon, LinkedInIcon, WhatsAppIcon } from '@/components/icons/SocialIcons';
 import CalPopupButton from '@/components/CalPopupButton';
+import { getScrollBehavior } from '@/lib/utils';
 
 /** Header nav. Routes (Services, Blog) + ancres homepage (Projets, Contact).
  * Quand on n'est pas sur la homepage, les ancres pointent vers `/#id` pour
@@ -110,7 +111,7 @@ export default function HeaderBar() {
 
   const scrollToSection = useCallback((e: React.MouseEvent, id: string) => {
     e.preventDefault();
-    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+    document.getElementById(id)?.scrollIntoView({ behavior: getScrollBehavior() });
     setMobileMenuOpen(false);
   }, []);
 
@@ -118,7 +119,9 @@ export default function HeaderBar() {
     (e: React.MouseEvent) => {
       if (!onHomepage) return;
       e.preventDefault();
-      document.getElementById('scroll-viewport')?.scrollTo({ top: 0, behavior: 'smooth' });
+      document
+        .getElementById('scroll-viewport')
+        ?.scrollTo({ top: 0, behavior: getScrollBehavior() });
     },
     [onHomepage],
   );

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { cn } from '../utils';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { cn, getScrollBehavior } from '../utils';
 
 describe('cn utility function', () => {
   it('merges class names correctly', () => {
@@ -72,5 +72,41 @@ describe('cn utility function', () => {
     // twMerge should keep the last conflicting class
     const result = cn('bg-red-500', 'bg-blue-500', 'text-white');
     expect(result).toBe('bg-blue-500 text-white');
+  });
+});
+
+describe('getScrollBehavior', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubMatchMedia(matches: boolean) {
+    const matchMedia = vi.fn((query: string) => ({
+      matches,
+      media: query,
+    }));
+    vi.stubGlobal('window', { matchMedia });
+    return matchMedia;
+  }
+
+  it("returns 'auto' when the user prefers reduced motion", () => {
+    const matchMedia = stubMatchMedia(true);
+    expect(getScrollBehavior()).toBe('auto');
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
+  });
+
+  it("returns 'smooth' when the user does not prefer reduced motion", () => {
+    stubMatchMedia(false);
+    expect(getScrollBehavior()).toBe('smooth');
+  });
+
+  it("falls back to 'smooth' when window is undefined (SSR)", () => {
+    vi.stubGlobal('window', undefined);
+    expect(getScrollBehavior()).toBe('smooth');
+  });
+
+  it("falls back to 'smooth' when matchMedia is unavailable", () => {
+    vi.stubGlobal('window', {});
+    expect(getScrollBehavior()).toBe('smooth');
   });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,20 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Returns the scroll behavior to use for programmatic scrolling, honoring the
+ * user's `prefers-reduced-motion` setting.
+ *
+ * The JS scroll APIs (`scrollTo`, `scrollIntoView`) ignore the CSS
+ * `scroll-behavior` property, so the reduced-motion rule in `globals.css` does
+ * not apply to them. Without this check, users who prefer reduced motion would
+ * still get animated scrolling. Falls back to `'smooth'` on the server / when
+ * `matchMedia` is unavailable.
+ */
+export function getScrollBehavior(): ScrollBehavior {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'smooth';
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
+}


### PR DESCRIPTION
## Contexte

La tâche demandait de trouver et d'implémenter un commentaire `TODO`. Après une recherche exhaustive de l'ensemble des fichiers suivis (`TODO`/`FIXME`/`HACK`/`XXX`/`TBD` + équivalents FR), **aucun marqueur de ce type n'existe dans le code**. Plutôt que d'en inventer un, j'ai implémenté une amélioration concrète et à faible risque.

## Problème

Les API de scroll JavaScript (`scrollTo` / `scrollIntoView` avec `behavior: 'smooth'`) **ignorent** la propriété CSS `scroll-behavior`. La règle `prefers-reduced-motion` présente dans `app/globals.css` (`scroll-behavior: auto`) ne s'applique donc **pas** à ces appels.

Conséquence : les personnes ayant activé « réduire les animations » subissaient quand même un défilement animé via :
- le bouton « Revenir en haut » (`BackToTop`)
- les liens d'ancre de la navigation (`HeaderBar`)

C'est en contradiction avec la bonne pratique d'accessibilité du projet (support de `useReducedMotion` documenté dans `CLAUDE.md`).

## Changements

- Ajout d'un utilitaire `getScrollBehavior()` dans `lib/utils.ts` qui renvoie `'auto'` quand l'utilisateur préfère réduire les animations, `'smooth'` sinon (fallback `'smooth'` côté serveur / si `matchMedia` indisponible).
- Utilisation de ce helper dans `BackToTop` et `HeaderBar` à la place des `behavior: 'smooth'` codés en dur.
- Ajout de 4 tests unitaires couvrant les cas reduced-motion, normal, SSR et absence de `matchMedia`.

## Vérifications

- `bun run test` — 59 tests passent (dont les 4 nouveaux)
- `bun run type-check` — OK
- `bun run lint` — OK
- `bun run format:check` — OK

https://claude.ai/code/session_013CVyk5PHS4tgMDqe2EjHgw

---
_Generated by [Claude Code](https://claude.ai/code/session_013CVyk5PHS4tgMDqe2EjHgw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scroll animations now respect user accessibility preferences, disabling smooth scrolling for those with reduced-motion settings enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VictorNain26/portfolio_site/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->