### PR TITLE
Harmonisation branding & wording du site

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -23,16 +23,16 @@ const blogBreadcrumbJsonLd = {
 export const metadata = {
   title: 'Blog',
   description:
-    'Articles sur le développement web, React, Next.js et les bonnes pratiques du code moderne.',
+    "Articles sur le développement web, l'intégration d'IA (agents, RAG, LLM) dans les produits et le métier de développeur freelance.",
   openGraph: {
     title: 'Blog | Victor Lenain',
-    description: 'Articles sur le développement web et les bonnes pratiques.',
+    description: "Développement web, intégration d'IA dans les produits et freelancing.",
     type: 'website',
     url: 'https://victorlenain.fr/blog',
   },
   twitter: {
     title: 'Blog | Victor Lenain',
-    description: 'Articles sur le développement web et les bonnes pratiques.',
+    description: "Développement web, intégration d'IA dans les produits et freelancing.",
   },
   alternates: {
     canonical: 'https://victorlenain.fr/blog',
@@ -54,7 +54,7 @@ export default function BlogIndex() {
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     name: 'Blog Victor Lenain',
-    description: 'Articles sur le développement web et les bonnes pratiques.',
+    description: "Développement web, intégration d'IA dans les produits et freelancing.",
     numberOfItems: publishedPosts.length,
     itemListElement: publishedPosts.map((post, index) => ({
       '@type': 'ListItem',
@@ -81,7 +81,8 @@ export default function BlogIndex() {
           Blog
         </h1>
         <p className="mt-4 max-w-lg text-lg leading-relaxed text-gray-400">
-          Réflexions sur le développement web, le freelancing et les bonnes pratiques du code.
+          Réflexions sur le développement web, l&apos;intégration d&apos;IA dans les produits et le
+          freelancing.
         </p>
       </header>
 

--- a/app/faq-data.ts
+++ b/app/faq-data.ts
@@ -1,0 +1,44 @@
+/**
+ * Source unique de la FAQ. Lue par le composant visible (`components/FAQ.tsx`)
+ * ET par le balisage `faqJsonLd` (`app/metadata-config.ts`). Une seule copie
+ * garantit que le contenu affiché et les données structurées ne divergent
+ * jamais — exigence des FAQ rich results de Google.
+ */
+export type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+export const faqItems: FaqItem[] = [
+  {
+    question: 'Quel est votre tarif journalier (TJM) ?',
+    answer:
+      'Mon TJM démarre à 500 € selon la complexité du projet, la durée de la mission et la stack. Devis détaillé proposé après notre premier échange.',
+  },
+  {
+    question: 'Êtes-vous disponible pour une mission ?',
+    answer:
+      'Je réponds sous 24 h ouvrées. Démarrage possible sous 1 à 2 semaines selon le planning en cours.',
+  },
+  {
+    question: 'Travaillez-vous en remote ?',
+    answer:
+      'Oui, principalement en remote. Je suis basé en région parisienne et je me déplace ponctuellement pour les réunions de lancement ou les ateliers importants.',
+  },
+  {
+    question: "Qu'avez-vous déjà livré côté IA ?",
+    answer:
+      "Deux produits IA livrés en solo : AubeSonore en production depuis 2025 (pipeline audio quotidien), TomIA en pré-prod pour 2026 (RAG sur programmes Éduscol, eval continue). Les briques que je propose en mission — serveur MCP, démo RAG, pipeline d'eval — sont publiées en open-source, lisibles avant signature. 4 ans à coder du web, dont 2 en Rails chez Capsens (fintech, 2022-2024) sur le code applicatif derrière.",
+  },
+  {
+    question: 'Combien de temps dure un projet type ?',
+    answer:
+      'Un site vitrine prend 2 à 4 semaines. Une application métier, 1 à 3 mois selon le périmètre. Je privilégie les livraisons itératives pour que vous ayez de la visibilité rapidement.',
+  },
+  {
+    question:
+      'Faites-vous des interventions courtes (correction de bug, refonte, ajout de fonctionnalité) ?',
+    answer:
+      "Oui : bug urgent, refonte ciblée, ajout de fonctionnalité, optimisation de perf, audit de stack. Intervention à partir d'une demi-journée, devis fixe sur les périmètres bornés.",
+  },
+];

--- a/app/metadata-config.ts
+++ b/app/metadata-config.ts
@@ -1,5 +1,7 @@
 // Configuration des métadonnées pour améliorer la lisibilité du layout
 
+import { faqItems } from './faq-data';
+
 export const personJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'Person',
@@ -118,51 +120,19 @@ export const websiteJsonLd = {
   },
 };
 
+/* Généré depuis la source unique `faqItems` pour rester strictement aligné
+ * sur la FAQ affichée (exigence des FAQ rich results de Google). */
 export const faqJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'FAQPage',
-  mainEntity: [
-    {
-      '@type': 'Question',
-      name: 'Quel est votre tarif journalier (TJM) ?',
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: 'Mon TJM démarre à 500\u00a0€ selon la complexité du projet, la durée de la mission et les technologies impliquées. Je propose toujours un devis détaillé après notre premier échange.',
-      },
+  mainEntity: faqItems.map(({ question, answer }) => ({
+    '@type': 'Question',
+    name: question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: answer,
     },
-    {
-      '@type': 'Question',
-      name: 'Êtes-vous disponible pour une mission ?',
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: 'Je réponds sous 24\u00a0h et le démarrage peut être très rapide, parfois quelques jours seulement, selon ma disponibilité du moment. Contactez-moi pour en discuter.',
-      },
-    },
-    {
-      '@type': 'Question',
-      name: 'Travaillez-vous en remote ?',
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: 'Oui, je travaille principalement en remote. Je suis basé en région parisienne et peux me déplacer ponctuellement pour des réunions, ateliers ou phases de lancement.',
-      },
-    },
-    {
-      '@type': 'Question',
-      name: 'Combien de temps dure un projet type ?',
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: 'Un site vitrine prend 2 à 4 semaines. Une application métier, 1 à 3 mois selon le périmètre. Je privilégie les livraisons itératives pour que vous ayez de la visibilité rapidement.',
-      },
-    },
-    {
-      '@type': 'Question',
-      name: 'Faites-vous des interventions courtes (fix, refonte, ajout de feature) ?',
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: "Oui. Je ne fais pas que des projets depuis zéro. Correction de bugs urgents, refonte d'un site existant, ajout d'une fonctionnalité, optimisation de performances. J'interviens ponctuellement à partir d'une demi-journée.",
-      },
-    },
-  ],
+  })),
 };
 
 export const professionalServiceJsonLd = {
@@ -171,7 +141,7 @@ export const professionalServiceJsonLd = {
   '@id': 'https://victorlenain.fr/#service',
   name: 'Victor Lenain · Développeur full-stack · Intégration IA',
   description:
-    "Greffe d'une couche IA (agents, RAG, automatisations LLM) sur votre stack web existante, sans refonte. Développement fullstack Next.js, Django, Rails, FastAPI. Freelance à Paris.",
+    "Greffe d'une couche IA (agents, RAG, automatisations LLM) sur votre stack web existante, sans refonte. Développement full-stack Next.js, Django, Rails, FastAPI. Freelance à Paris.",
   url: 'https://victorlenain.fr',
   image: 'https://victorlenain.fr/og-image.png',
   priceRange: '€€',
@@ -223,7 +193,7 @@ export const professionalServiceJsonLd = {
       ],
     },
     name: 'Prendre rendez-vous',
-    description: 'Réserver un appel découverte gratuit de 30 minutes',
+    description: 'Réserver un échange découverte gratuit de 15 minutes',
   },
   hasOfferCatalog: {
     '@type': 'OfferCatalog',

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -62,7 +62,7 @@ export default function OGImage() {
           textAlign: 'center',
         }}
       >
-        Votre projet web, <span style={{ color: '#818cf8' }}>avec ou sans IA</span>
+        La couche IA sur votre <span style={{ color: '#818cf8' }}>stack existante</span>
       </h1>
 
       {/* Sous-titre */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import Process from '@/components/Process';
 import Projects from '@/components/Projects';
 import FAQ from '@/components/FAQ';
 import LatestPosts from '@/components/LatestPosts';
+import Testimonials from '@/components/Testimonials';
 import Contact from '@/components/Contact';
 
 export default function Home() {
@@ -28,6 +29,7 @@ export default function Home() {
       <Process />
       <FAQ />
       <LatestPosts posts={latestPosts} />
+      <Testimonials />
       <Contact />
     </main>
   );

--- a/app/services/[slug]/page.tsx
+++ b/app/services/[slug]/page.tsx
@@ -185,6 +185,10 @@ export default async function ServicePage({ params }: { params: Promise<{ slug: 
                 </span>
               ))}
             </div>
+            <p className="mt-4 text-sm leading-relaxed text-gray-500">
+              Repères, pas une liste de prérequis. Je m&apos;adapte à votre stack et à vos outils en
+              place.
+            </p>
           </FadeOnView>
         </Section>
 

--- a/app/services/content.ts
+++ b/app/services/content.ts
@@ -80,18 +80,7 @@ export const services: Service[] = [
       "Je borne l'agent sur trois workflows précis avec un schéma d'entrée et de sortie typés. Chaque appel d'outil passe par votre API existante, jamais par une réécriture de votre back-office. L'agent ne sait pas faire autre chose que ces trois choses, et c'est ce qui le rend fiable.",
       "Eval en place dès le premier sprint sur un dataset de cas réels que vous validez. Coûts tokens estimés au cadrage et trackés en prod avec un dashboard. Retry et fallback prévus si l'API du modèle tombe. Logs structurés pour rejouer une session à l'identique en cas de comportement étrange.",
     ],
-    stack: [
-      'TypeScript',
-      'Python',
-      'Node.js',
-      'FastAPI',
-      'Anthropic Claude',
-      'OpenAI',
-      'Mistral',
-      'PostgreSQL',
-      'Langfuse',
-      'Docker',
-    ],
+    stack: ['TypeScript', 'Python', 'FastAPI', 'Anthropic Claude', 'OpenAI', 'Langfuse'],
     useCases: [
       {
         title: 'Tri et qualification de leads entrants',
@@ -162,18 +151,7 @@ export const services: Service[] = [
       "Pipeline complète d'ingestion depuis vos sources (Drive, Notion, Confluence, PDF, base interne) avec découpage qui respecte la structure du document. Embeddings choisis selon la langue principale de votre corpus. Stockage dans pgvector si vous êtes déjà sur PostgreSQL, Qdrant si on dépasse le million de chunks ou s'il faut du filtrage multi-tenant.",
       "Recherche sémantique avec reranking, génération sous contrainte de citation, vérification post-génération que chaque citation existe dans les sources retournées. Pipeline d'indexation incrémentale pour ne pas tout rebâtir à chaque mise à jour. Eval recall@k et faithfulness mesurés sur un dataset golden que vous validez au cadrage.",
     ],
-    stack: [
-      'pgvector',
-      'Qdrant',
-      'Mistral Embed',
-      'OpenAI Embeddings',
-      'Anthropic Claude',
-      'Ragas',
-      'Langfuse',
-      'Python',
-      'PostgreSQL',
-      'Docker',
-    ],
+    stack: ['pgvector', 'Qdrant', 'Mistral Embed', 'Anthropic Claude', 'Ragas', 'Python'],
     useCases: [
       {
         title: 'Assistant sur jurisprudence ou contrats internes',
@@ -242,19 +220,7 @@ export const services: Service[] = [
       'Pipeline codée en Python ou Node.js comme du vrai code : sortie typée et validée par schéma (Pydantic, Zod), tests sur les cas connus, retry avec backoff, batch quand le volume le justifie. Coûts tokens estimés au cadrage avec hypothèses écrites, puis trackés en prod sur un dashboard que vous lisez sans moi.',
       'Eval automatique sur un dataset de référence : si la qualité baisse après un changement de modèle ou un ajustement de prompt, vous le voyez avant la prod. Chaque choix (modèle, prompt, batch size) est justifié par des chiffres mesurés sur votre corpus, pas par mode.',
     ],
-    stack: [
-      'Python',
-      'Node.js',
-      'Pydantic',
-      'Zod',
-      'OpenAI',
-      'Anthropic Claude',
-      'Mistral',
-      'Ragas',
-      'Langfuse',
-      'PostgreSQL',
-      'Docker',
-    ],
+    stack: ['Python', 'Node.js', 'Pydantic', 'Anthropic Claude', 'OpenAI', 'Langfuse'],
     useCases: [
       {
         title: 'Extraction structurée depuis factures et PDF',
@@ -276,7 +242,7 @@ export const services: Service[] = [
       {
         question: "Quel est le coût typique d'une pipeline LLM en production ?",
         answer:
-          "De quelques euros par mois sur des volumes faibles avec un petit modèle, à plusieurs milliers sur des millions de requêtes mensuelles. J'estime au cadrage à partir de votre volume cible, avec un buffer explicite pour les pics. Vous repartez avec un fichier que vous pouvez challenger ligne par ligne.",
+          "De quelques euros par mois sur des volumes faibles avec un petit modèle, à plusieurs milliers sur des millions de requêtes mensuelles. J'estime au cadrage à partir de votre volume cible, avec un buffer explicite pour les pics. Vous repartez avec un fichier chiffré, vérifiable poste par poste.",
       },
       {
         question: 'Vous utilisez quel modèle par défaut ?',
@@ -322,17 +288,7 @@ export const services: Service[] = [
       'Je prends le projet du cadrage au déploiement. Stack selon le contexte : Next.js 15 + TypeScript pour un produit moderne, Rails 7 + PostgreSQL si vous avez besoin de monter vite sur du métier, Node.js pour les APIs. Tests sur les parties qui le méritent, pas sur le CRUD trivial.',
       "Si vous voulez greffer du LLM sur l'app (résumé automatique, classification d'inputs, recherche sémantique sur vos contenus), on en parle au cadrage et on chiffre. Sinon, je livre l'app web sans pousser de l'IA partout. Le but, c'est que le projet sorte et tourne.",
     ],
-    stack: [
-      'Next.js 15',
-      'TypeScript',
-      'React 19',
-      'Ruby on Rails',
-      'Node.js',
-      'PostgreSQL',
-      'Tailwind',
-      'Vercel',
-      'Docker',
-    ],
+    stack: ['Next.js 15', 'TypeScript', 'React 19', 'Ruby on Rails', 'Node.js', 'PostgreSQL'],
     useCases: [
       {
         title: 'Plateforme SaaS B2B (auth, paiement, dashboard)',
@@ -395,16 +351,7 @@ export const services: Service[] = [
       "Demi-journée minimum. D'abord 1 à 2 heures d'audit pour lire le code, comprendre l'historique et identifier la cause racine. Ensuite un plan chiffré : ce qu'on touche, ce qu'on laisse, le risque associé. Vous validez, j'exécute. Pas de surprise sur la facture.",
       'Je préfère réparer que réécrire. Une migration de framework se fait en branches, par modules, avec rollback possible à chaque étape. Une optimisation Core Web Vitals se mesure avant et après, avec des chiffres. Un fix en prod se livre avec un test qui empêche la régression.',
     ],
-    stack: [
-      'Next.js',
-      'React',
-      'Vue',
-      'Ruby on Rails',
-      'Node.js',
-      'WordPress',
-      'Python',
-      'PostgreSQL',
-    ],
+    stack: ['Next.js', 'React', 'Vue', 'Ruby on Rails', 'Node.js', 'WordPress'],
     useCases: [
       {
         title: 'Migration React 17 → 19 ou Next.js majeur',
@@ -467,17 +414,7 @@ export const services: Service[] = [
       "Je lis votre code, vos prompts, votre architecture, vos coûts actuels. Je liste les choix qui vont vous coûter cher s'ils sont mal pris : modèle, structure de prompt, infra de retrieval, évaluation, fournisseur. Puis je vous remets une note de 4 à 10 pages, signée, avec recommandations classées par priorité.",
       "Si après audit ma conclusion c'est que l'IA n'apporte rien à votre cas et qu'une règle métier ou un script Python suffit, je l'écris dans la note. Vous me payez l'audit, pas un argumentaire pour vendre la mission qui suit.",
     ],
-    stack: [
-      'Anthropic',
-      'OpenAI',
-      'Mistral',
-      'Llama auto-hébergé',
-      'pgvector',
-      'Qdrant',
-      'LangChain',
-      'Ragas',
-      'Langfuse',
-    ],
+    stack: ['Anthropic', 'OpenAI', 'Mistral', 'pgvector', 'Ragas', 'Langfuse'],
     useCases: [
       {
         title: "Cadrage d'un prototype IA",

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -67,11 +67,11 @@ export default function ServicesIndexPage() {
               Services
             </p>
             <h1 className="font-display text-4xl leading-[1.05] font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
-              Je code la couche IA dans votre produit existant.
+              Je code la couche IA dans votre stack existante.
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-gray-300 sm:text-xl">
-              Développeur fullstack freelance à Paris. Je greffe la couche IA sur votre stack web
-              (Next, Django, FastAPI, Postgres) sans refonte. Trois prestations pour
+              Développeur full-stack freelance à Paris. Je greffe la couche IA sur votre stack web
+              (Next, Django, Rails, FastAPI) sans refonte. Trois prestations pour
               l&apos;intégration, trois autres pour le reste du produit web.
             </p>
           </FadeOnView>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -30,7 +30,7 @@ export default function Contact() {
             data-umami-event="cta-contact-cal"
           >
             <Calendar aria-hidden className="h-5 w-5" />
-            Réserver un call de 15&nbsp;min
+            Réserver un échange de 15&nbsp;min
             <ArrowRight
               aria-hidden
               className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1"

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -6,40 +6,7 @@ import Section from '@/components/Section';
 import SectionHeading from '@/components/SectionHeading';
 import FadeOnView from '@/components/FadeOnView';
 import { cn } from '@/lib/utils';
-
-const faqItems = [
-  {
-    question: 'Quel est votre tarif journalier (TJM) ?',
-    answer:
-      'Mon TJM démarre à 500 € selon la complexité du projet, la durée de la mission et la stack. Devis détaillé proposé après notre premier échange.',
-  },
-  {
-    question: 'Êtes-vous disponible pour une mission ?',
-    answer:
-      'Je réponds sous 24 h ouvrées. Démarrage possible sous 1 à 2 semaines selon le planning en cours.',
-  },
-  {
-    question: 'Travaillez-vous en remote ?',
-    answer:
-      'Oui, principalement en remote. Je suis basé en région parisienne et je me déplace ponctuellement pour les réunions de lancement ou les ateliers importants.',
-  },
-  {
-    question: "Qu'avez-vous déjà livré côté IA ?",
-    answer:
-      "Deux produits IA livrés en solo : AubeSonore en production depuis 2025 (pipeline audio quotidien), TomIA en pré-prod pour 2026 (RAG sur programmes Éduscol, eval continue). Les briques que je propose en mission — serveur MCP, démo RAG, pipeline d'eval — sont publiées en open-source, lisibles avant signature. 4 ans de Rails en prod chez Capsens (fintech, 2022-2024) sur le code applicatif derrière.",
-  },
-  {
-    question: 'Combien de temps dure un projet type ?',
-    answer:
-      'Un site vitrine prend 2 à 4 semaines. Une application métier, 1 à 3 mois selon le périmètre. Je privilégie les livraisons itératives pour que vous ayez de la visibilité rapidement.',
-  },
-  {
-    question:
-      'Faites-vous des interventions courtes (correction de bug, refonte, ajout de fonctionnalité) ?',
-    answer:
-      "Oui : bug urgent, refonte ciblée, ajout de fonctionnalité, optimisation de perf, audit de stack. Intervention à partir d'une demi-journée, devis fixe sur les périmètres bornés.",
-  },
-];
+import { faqItems } from '@/app/faq-data';
 
 export default function FAQ() {
   const [openIndex, setOpenIndex] = useState<number | null>(null);

--- a/components/HeaderBar.tsx
+++ b/components/HeaderBar.tsx
@@ -27,7 +27,7 @@ const NAV_LINKS: NavLink[] = [
 const TRACKED_SECTION_IDS = ['projets', 'contact'] as const;
 
 const socials = [
-  { href: 'https://github.com/victornain26', Icon: GitHubIcon, label: 'GitHub' },
+  { href: 'https://github.com/VictorNain26', Icon: GitHubIcon, label: 'GitHub' },
   {
     href: 'https://www.linkedin.com/in/victorlenain/',
     Icon: LinkedInIcon,

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -50,7 +50,7 @@ export default function Hero() {
           className="text-lead mt-6 max-w-2xl text-pretty text-gray-300 sm:text-xl"
           delay={0.1}
         >
-          Développeur fullstack freelance à Paris, 4 ans en production. Sans refonte de votre stack.
+          Développeur full-stack freelance à Paris, 4 ans en production. Sans refonte de votre stack.
         </FadeOnView>
 
         <FadeOnView className="mt-9 flex flex-wrap items-center gap-x-6 gap-y-3" delay={0.15}>
@@ -83,7 +83,7 @@ export default function Hero() {
           delay={0.2}
         >
           <p className="label-mono flex flex-wrap items-center gap-x-3 gap-y-1.5 text-gray-500">
-            <span>Fullstack + IA</span>
+            <span>Full-stack + IA</span>
             <span aria-hidden="true" className="text-gray-700">
               ·
             </span>

--- a/components/LatestPosts.tsx
+++ b/components/LatestPosts.tsx
@@ -18,7 +18,7 @@ export default function LatestPosts({ posts }: { posts: Post[] }) {
     <Section className="scroll-mt-28 pb-12">
       <SectionHeading
         index="05"
-        label="Journal"
+        label="Blog"
         title="Je partage ce que j'apprends."
         aside={
           <Link

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -79,7 +79,7 @@ export default function Services() {
 
       {/* Secondaires : plus discret, plus dense */}
       <FadeOnView className="mt-12" delay={0.2}>
-        <p className="label-mono mb-5 text-gray-500">Aussi disponible pour</p>
+        <p className="label-mono mb-5 text-gray-500">Au-delà de l'IA</p>
         <div className="grid gap-4 sm:grid-cols-3">
           {secondary.map(service => {
             const Icon = service.icon;


### PR DESCRIPTION
## Contexte

Audit branding/wording de l'ensemble du site, puis correction des incohérences relevées. Le positionnement de fond (« dev full-stack freelance qui greffe la couche IA sur une stack existante, sans refonte ») est solide ; ce sont des dérives d'exécution qui sont corrigées ici.

## 🔴 Corrections critiques

- **Contradiction factuelle (crédibilité)** — la FAQ affirmait « 4 ans de Rails en prod chez Capsens (2022-2024) », or 2022-2024 = 2 ans. Aligné sur « 4 ans à coder du web, dont 2 en Rails chez Capsens ».
- **FAQ structurée ≠ FAQ affichée (SEO)** — le balisage `FAQPage` divergeait du contenu visible (délai de démarrage « quelques jours » vs « 1 à 2 semaines », 5 questions vs 6, wording TJM). Création d'une **source unique** `app/faq-data.ts`, lue à la fois par le composant et par le JSON-LD → plus de divergence possible.
- **Durée d'échange** — 15 min partout dans l'UI mais 30 min dans le JSON-LD `ReserveAction`. Uniformisé sur 15 min.
- **OG image** — le H1 « Votre projet web, avec ou sans IA » (généraliste) diluait le positionnement sur l'image partagée. Remplacé par « La couche IA sur votre stack existante ».

## 🟠 Cohérence terminologique

- `fullstack` → **`full-stack`** partout (le visible et les métadonnées divergeaient).
- Suppression de l'anglicisme « call » → « Réserver un échange ».
- Libellé des services secondaires unifié sur « Au-delà de l'IA ».
- Section blog de la home : « Journal » → « Blog ».
- Liste stack canonique (Next, Django, Rails, FastAPI) sur la page Services (Rails était omis).
- H1 page Services : « produit existant » → « stack existante » (aligné sur la home).
- Handle GitHub uniformisé (`VictorNain26`).

## 🟡 Contenu & preuve sociale

- **Moins de name-dropping techno** : listes de stack par service ramenées à ≤ 6 repères (retrait des briques génériques/répétées — Docker, PostgreSQL en doublon, etc.) + note « Repères, pas des prérequis — je m'adapte à votre stack » sur les pages service.
- Section **Testimonials** montée sur la home (le composant n'était rendu nulle part → code mort + zéro preuve sociale).
- Description du blog élargie à l'intégration d'IA (était restée sur l'ancien positionnement « dev web » pur).
- Déduplication d'une formule répétée à l'identique sur deux services.

## Vérifications

- `bun run type-check` ✅
- `bun run lint` ✅ (seuls des warnings préexistants)
- `bun run test` ✅ — 102/102

https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi

---
_Generated by [Claude Code](https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi)_