### PR TITLE
Refonte parcours — étape 1/4 : structure & ponts de conversion

### DIFF
--- a/app/metadata-config.ts
+++ b/app/metadata-config.ts
@@ -94,9 +94,9 @@ export const websiteJsonLd = {
       },
       {
         '@type': 'SiteNavigationElement',
-        name: 'À propos',
-        description: 'Expérience et compétences techniques',
-        url: 'https://victorlenain.fr#a-propos',
+        name: 'Services',
+        description: 'Intégration IA, applications web, refonte et audit',
+        url: 'https://victorlenain.fr/services',
       },
       {
         '@type': 'SiteNavigationElement',

--- a/app/services/[slug]/page.tsx
+++ b/app/services/[slug]/page.tsx
@@ -249,6 +249,47 @@ export default async function ServicePage({ params }: { params: Promise<{ slug: 
           </Section>
         )}
 
+        {/* Maillage inter-services : si ce service n'est pas le bon fit, le
+         * visiteur garde un chemin vers les autres prestations sans repasser
+         * par l'index. */}
+        <Section className="pb-16">
+          <FadeOnView className="mb-8 flex items-center gap-3">
+            <span aria-hidden="true" className="h-px w-8 bg-gray-600/60" />
+            <p className="text-xs font-medium tracking-[0.18em] text-gray-500 uppercase">
+              Autres prestations
+            </p>
+          </FadeOnView>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {services
+              .filter(s => s.slug !== service.slug)
+              .map((s, i) => {
+                const a = ACCENT_CLASSES[s.accent];
+                const SIcon = s.icon;
+                return (
+                  <FadeOnView key={s.slug} delay={0.04 * i}>
+                    <Link
+                      className={`group flex h-full gap-4 rounded-xl border border-line-1 bg-surface-1 p-5 transition-colors duration-300 ${a.hoverBorder} hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:outline-none`}
+                      data-umami-event={`xlink-${service.slug}-to-${s.slug}`}
+                      href={`/services/${s.slug}`}
+                    >
+                      <div
+                        className={`shrink-0 ${a.text} transition-transform group-hover:-translate-y-0.5`}
+                      >
+                        <SIcon aria-hidden="true" className="h-5 w-5" />
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <h3 className="text-sm font-semibold text-gray-200">{s.shortTitle}</h3>
+                        <p className="line-clamp-2 text-xs leading-relaxed text-gray-500">
+                          {s.tagline}
+                        </p>
+                      </div>
+                    </Link>
+                  </FadeOnView>
+                );
+              })}
+          </div>
+        </Section>
+
         {/* CTA bottom */}
         <Section className="pb-24">
           <FadeOnView className="relative mx-auto max-w-3xl overflow-hidden rounded-3xl border border-line-2 bg-surface-1 px-6 py-14 text-center backdrop-blur-sm sm:px-12">

--- a/components/ArticleLayout.tsx
+++ b/components/ArticleLayout.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import ShareButton from '@/components/ShareButton';
-import { ArrowLeft } from 'lucide-react';
+import CalPopupButton from '@/components/CalPopupButton';
+import { ArrowLeft, ArrowRight, Calendar } from 'lucide-react';
 
 type Post = {
   title: string;
@@ -118,6 +119,45 @@ export default function ArticleLayout({
           >
             GitHub
           </a>
+        </div>
+      </aside>
+
+      {/* ---------- PONT VERS LA CONVERSION ----------
+       * Le blog est une porte d'entrée SEO majeure ; sans relance, le lecteur
+       * repart sans étape suivante. Cet encart le ramène vers l'échange ou les
+       * services, au moment où le sujet est encore frais. */}
+      <aside className="relative mt-8 overflow-hidden rounded-2xl border border-brand-hover/25 bg-surface-1 p-6 text-center backdrop-blur-sm sm:p-8">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-brand-hover/50 to-transparent"
+        />
+        <h2 className="font-display text-xl font-bold text-white sm:text-2xl">
+          Un projet derrière cette lecture&nbsp;?
+        </h2>
+        <p className="mx-auto mt-3 max-w-md text-sm leading-relaxed text-gray-400">
+          Si la question se pose pour votre produit, autant en parler. 15&nbsp;min pour cadrer le
+          besoin — je vous dis franchement si c&apos;est pertinent, et sinon je vous oriente.
+        </p>
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+          <CalPopupButton
+            className="group inline-flex items-center gap-2.5 rounded-full bg-brand px-6 py-3 text-sm font-semibold text-white shadow-glow transition-all duration-300 hover:-translate-y-0.5 hover:bg-brand-hover hover:shadow-glow-lg focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:outline-none"
+            data-umami-event="cta-article-cal"
+          >
+            <Calendar aria-hidden="true" className="h-4 w-4" />
+            Réserver un échange de 15&nbsp;min
+            <ArrowRight
+              aria-hidden="true"
+              className="h-4 w-4 transition-transform group-hover:translate-x-1"
+            />
+          </CalPopupButton>
+          <Link
+            className="inline-flex items-center gap-2 rounded-full border border-line-2 bg-surface-2 px-5 py-2.5 text-sm font-medium text-gray-300 transition-colors hover:border-line-5 hover:text-white focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:outline-none"
+            data-umami-event="cta-article-services"
+            href="/services"
+          >
+            Voir les services
+            <ArrowRight aria-hidden="true" className="h-3.5 w-3.5" />
+          </Link>
         </div>
       </aside>
 


### PR DESCRIPTION
**Étape 1/4 de la refonte** (objectif global : convertir au maximum, livré par étapes validables).
Direction retenue : *garder l'ADN visuel (sombre/techy/indigo), tout élever* — préserve le capital SEO et la voix de marque qui signalent la compétence à la cible la plus exigeante (le CTO évaluateur).

> 📌 PR **empilée** sur `claude/sleepy-hawking-b1fgr` (branding, PR #56) pour éviter les conflits sur `metadata-config.ts`. À fusionner après #56 (GitHub re-ciblera automatiquement la base sur `master` une fois #56 mergée).

## Pourquoi cette étape

Le tunnel de conversion était soigné **sur la home**, mais la home n'est pas la porte d'entrée principale : le SEO fait atterrir les visiteurs sur une page service ou un article. Cette étape s'assure que **chaque point d'entrée porte son propre mini-funnel** et qu'aucun parcours ne se termine en cul-de-sac.

## Changements

- **🔴 Pont blog → conversion** (`ArticleLayout`) — encart de fin d'article : « Un projet derrière cette lecture ? » + *Réserver un échange* + *Voir les services*. Le blog (entrée SEO majeure) se terminait sur LinkedIn/GitHub uniquement — c'était la principale fuite de conversion.
- **🟠 Maillage inter-services** (`/services/[slug]`) — bloc « Autres prestations » listant les 5 autres offres. Un visiteur qui n'est pas le bon fit pour un service garde un chemin vers les autres sans repasser par l'index. (events Umami `xlink-<from>-to-<to>` pour mesurer.)
- **🟡 Intégrité des données structurées** — l'ancre `#a-propos` du JSON-LD était morte (aucune section ni route). Remplacée par une entrée « Services » → `/services` (page réelle et à plus forte valeur de conversion).

## Hors périmètre (étapes suivantes, PRs dédiées)

2. Design & composants (élévation visuelle)
3. Copywriting double-étage (résultat business pour le dirigeant *puis* profondeur technique pour le CTO)
4. Conversion & technique : modale Cal inline (au lieu du nouvel onglet), vraie preuve sociale, retour au scroll natif (gain mobile)

Le **réordonnancement de la home** (cluster preuve sociale après Projets) est volontairement reporté à l'étape 3/4 : remonter un encart témoignages *vide* nuirait à la conversion tant qu'il n'y a pas de vrai témoignage.

## Vérifications

- `bun run type-check` ✅
- `bun run lint` ✅ (warnings préexistants uniquement)
- `bun run test` ✅ — 102/102
- `prettier --check` ✅

https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi

---
_Generated by [Claude Code](https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi)_