### PR TITLE
Refonte design — étape 2/4 : cohérence visuelle (eyebrows & titres)

### DIFF
--- a/app/services/[slug]/page.tsx
+++ b/app/services/[slug]/page.tsx
@@ -91,9 +91,7 @@ export default async function ServicePage({ params }: { params: Promise<{ slug: 
               className={`mb-6 inline-flex items-center gap-3 rounded-full border px-4 py-2 ${accent.border} ${accent.bg}`}
             >
               <Icon aria-hidden="true" className={`h-4 w-4 ${accent.text}`} />
-              <span className={`text-xs font-medium tracking-[0.18em] uppercase ${accent.text}`}>
-                {service.shortTitle}
-              </span>
+              <span className={`label-mono ${accent.text}`}>{service.shortTitle}</span>
             </div>
             <h1 className="font-display text-4xl leading-[1.05] font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
               {service.title}
@@ -140,9 +138,7 @@ export default async function ServicePage({ params }: { params: Promise<{ slug: 
         <Section className="pb-16">
           <div className="grid gap-10 lg:grid-cols-2">
             <FadeOnView delay={0.05}>
-              <p className="mb-3 text-xs font-medium tracking-[0.18em] text-warm/80 uppercase">
-                Le contexte
-              </p>
+              <p className="label-mono mb-3 text-warm/80">Le contexte</p>
               <h2 className="font-display text-2xl font-semibold text-white sm:text-3xl">
                 Pourquoi c&apos;est dur à bien faire
               </h2>
@@ -154,9 +150,7 @@ export default async function ServicePage({ params }: { params: Promise<{ slug: 
             </FadeOnView>
 
             <FadeOnView delay={0.1}>
-              <p className={`mb-3 text-xs font-medium tracking-[0.18em] uppercase ${accent.text}`}>
-                Mon approche
-              </p>
+              <p className={`label-mono mb-3 ${accent.text}`}>Mon approche</p>
               <h2 className="font-display text-2xl font-semibold text-white sm:text-3xl">
                 Comment je le fais
               </h2>
@@ -172,9 +166,7 @@ export default async function ServicePage({ params }: { params: Promise<{ slug: 
         {/* Stack */}
         <Section className="pb-16">
           <FadeOnView className="max-w-3xl">
-            <p className="mb-3 text-xs font-medium tracking-[0.18em] text-gray-500 uppercase">
-              Stack & outils
-            </p>
+            <p className="label-mono mb-3 text-gray-500">Stack & outils</p>
             <div className="flex flex-wrap gap-2">
               {service.stack.map(t => (
                 <span
@@ -195,12 +187,8 @@ export default async function ServicePage({ params }: { params: Promise<{ slug: 
         {/* Use cases */}
         <Section className="pb-16">
           <FadeOnView className="mb-10 max-w-2xl">
-            <p className={`mb-3 text-xs font-medium tracking-[0.18em] uppercase ${accent.text}`}>
-              Cas d&apos;usage
-            </p>
-            <h2 className="font-display text-3xl leading-[1.1] font-bold text-white sm:text-4xl">
-              Ce que ça donne en vrai
-            </h2>
+            <p className={`label-mono mb-3 ${accent.text}`}>Cas d&apos;usage</p>
+            <h2 className="heading-2 text-white">Ce que ça donne en vrai</h2>
           </FadeOnView>
 
           <div className="grid gap-6 lg:grid-cols-3">
@@ -226,12 +214,8 @@ export default async function ServicePage({ params }: { params: Promise<{ slug: 
         {service.faq.length > 0 && (
           <Section className="pb-16">
             <FadeOnView className="mb-10 max-w-2xl">
-              <p className="mb-3 text-xs font-medium tracking-[0.18em] text-brand-accent uppercase">
-                Questions fréquentes
-              </p>
-              <h2 className="font-display text-3xl leading-[1.1] font-bold text-white sm:text-4xl">
-                Ce qu&apos;on me demande sur ce sujet
-              </h2>
+              <p className="label-mono mb-3 text-brand-accent">Questions fréquentes</p>
+              <h2 className="heading-2 text-white">Ce qu&apos;on me demande sur ce sujet</h2>
             </FadeOnView>
 
             <div className="mx-auto max-w-3xl space-y-3">
@@ -255,9 +239,7 @@ export default async function ServicePage({ params }: { params: Promise<{ slug: 
         <Section className="pb-16">
           <FadeOnView className="mb-8 flex items-center gap-3">
             <span aria-hidden="true" className="h-px w-8 bg-gray-600/60" />
-            <p className="text-xs font-medium tracking-[0.18em] text-gray-500 uppercase">
-              Autres prestations
-            </p>
+            <p className="label-mono text-gray-500">Autres prestations</p>
           </FadeOnView>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {services

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -63,9 +63,7 @@ export default function ServicesIndexPage() {
         {/* Hero + premier bloc collés visuellement */}
         <Section className="pb-10">
           <FadeOnView className="max-w-3xl">
-            <p className="mb-3 font-display text-sm font-medium tracking-[0.18em] text-brand-accent uppercase">
-              Services
-            </p>
+            <p className="label-mono text-brand-accent">Services</p>
             <h1 className="font-display text-4xl leading-[1.05] font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
               Je code la couche IA dans votre stack existante.
             </h1>
@@ -81,9 +79,7 @@ export default function ServicesIndexPage() {
         <Section className="pb-14">
           <FadeOnView className="mb-6 flex items-center gap-3">
             <span aria-hidden="true" className="h-px w-8 bg-brand-accent/60" />
-            <p className="text-xs font-medium tracking-[0.18em] text-brand-accent uppercase">
-              Intégration IA
-            </p>
+            <p className="label-mono text-brand-accent">Intégration IA</p>
           </FadeOnView>
 
           <div className="grid gap-5 lg:grid-cols-3">
@@ -127,9 +123,7 @@ export default function ServicesIndexPage() {
         <Section className="pb-16">
           <FadeOnView className="mb-6 flex items-center gap-3">
             <span aria-hidden="true" className="h-px w-8 bg-gray-600/60" />
-            <p className="text-xs font-medium tracking-[0.18em] text-gray-500 uppercase">
-              Au-delà de l&apos;IA
-            </p>
+            <p className="label-mono text-gray-500">Au-delà de l&apos;IA</p>
           </FadeOnView>
 
           <div className="grid gap-4 sm:grid-cols-3">

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -11,12 +11,8 @@ export default function Testimonials() {
   return (
     <Section className="scroll-mt-28 pb-20" id="temoignages">
       <FadeOnView className="mb-12 max-w-2xl">
-        <p className="mb-3 font-display text-sm font-medium tracking-[0.18em] text-brand-accent uppercase">
-          Retour mission
-        </p>
-        <h2 className="font-display text-3xl leading-[1.1] font-bold text-white sm:text-4xl lg:text-5xl">
-          On a déjà travaillé ensemble ?
-        </h2>
+        <p className="label-mono mb-3 text-brand-accent">Retour mission</p>
+        <h2 className="heading-2 text-white">On a déjà travaillé ensemble ?</h2>
         <p className="mt-5 text-base leading-relaxed text-gray-400">
           Un retour court sur la collaboration aide énormément les futurs clients à se décider.
           Anonyme si vous préférez.
@@ -28,9 +24,7 @@ export default function Testimonials() {
           className="flex flex-col items-start gap-5 rounded-2xl border border-dashed border-line-4 bg-surface-1 p-7 text-left"
           delay={0.1}
         >
-          <p className="text-[11px] font-medium tracking-[0.18em] text-gray-500 uppercase">
-            Votre retour ici
-          </p>
+          <p className="label-mono text-gray-500">Votre retour ici</p>
           <a
             className="inline-flex w-fit items-center gap-1.5 text-sm font-medium text-brand-light transition-colors hover:text-brand-lighter"
             href="mailto:victor.lenain26@gmail.com?subject=Retour%20mission"


### PR DESCRIPTION
**Étape 2/4 de la refonte.** Direction : *garder l'ADN (sombre / indigo / Geist), élever par la cohérence.*

> 📌 PR **empilée** sur l'étape 1 (#57). Ordre de fusion : #56 → #57 → cette PR → `master` (GitHub re-cible les bases automatiquement au fil des merges).

## Pourquoi

Le système de design est déjà soigné (tokens surfaces/lignes/brand, primitives `heading-1/2`, `label-mono`, `text-lead`). Le principal défaut de finition : **deux langages d'« eyebrow » coexistaient** —
- la signature `label-mono` (monospace, tracking large = identité « documentaire ») sur la home,
- un eyebrow **sans-serif** (`text-xs tracking-[0.18em] uppercase`) sur les pages internes (services, service détaillé, témoignages).

Cette incohérence typographique cassait l'impression de cohésion d'une page à l'autre. L'élévation la plus rentable et la moins risquée est de parler **une seule langue visuelle** partout.

## Changements

- **`/services` et `/services/[slug]`** : tous les eyebrows de section (badge hero, *Le contexte*, *Mon approche*, *Stack & outils*, *Cas d'usage*, *Questions fréquentes*, *Autres prestations*) passent en `label-mono`. Les couleurs d'accent par service sont conservées.
- **Testimonials** : eyebrow → `label-mono`, titre → primitive `heading-2` (l'outlier s'aligne sur les sections de la home).
- **Titres de sections pleine largeur** (« Ce que ça donne en vrai », « Ce qu'on me demande ») → primitive `heading-2`, comme sur la home.
- Les **titres de cartes/CTA** (« On en parle ? », contact) gardent leur taille réduite : hiérarchie volontaire *section* vs *carte*.

Aucun changement de couleurs, d'espacements de fond, ni de structure — purement de la cohérence typographique.

## Vérifications

- `bun run type-check` ✅
- `bun run lint` ✅
- `bun run test` ✅ — 102/102
- `prettier --check` ✅

## Suite

3/4 — Copywriting double-étage (dirigeant *puis* CTO) · 4/4 — Conversion & technique (modale Cal, preuve sociale, scroll natif).

https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi

---
_Generated by [Claude Code](https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi)_