### PR TITLE
Refonte copy — étape 3/4 : double-étage dirigeant / CTO

### DIFF
--- a/app/services/[slug]/page.tsx
+++ b/app/services/[slug]/page.tsx
@@ -134,6 +134,17 @@ export default async function ServicePage({ params }: { params: Promise<{ slug: 
           </FadeOnView>
         </Section>
 
+        {/* Le résultat (étage « dirigeant ») — placé avant la profondeur
+         * technique pour répondre d'abord au « ça m'apporte quoi ? ». */}
+        <Section className="pb-16">
+          <FadeOnView className="max-w-3xl">
+            <p className={`label-mono mb-4 ${accent.text}`}>Le résultat pour vous</p>
+            <p className="text-xl leading-relaxed text-balance text-gray-200 sm:text-2xl sm:leading-relaxed">
+              {service.outcome}
+            </p>
+          </FadeOnView>
+        </Section>
+
         {/* Problem + Approach split */}
         <Section className="pb-16">
           <div className="grid gap-10 lg:grid-cols-2">

--- a/app/services/content.ts
+++ b/app/services/content.ts
@@ -23,6 +23,9 @@ export type Service = {
   title: string;
   /** One-line under H1. */
   tagline: string;
+  /** Étage « dirigeant » : le résultat concret pour le client, en langage
+   * business sans jargon, rendu en tête de page avant la profondeur technique. */
+  outcome: string;
   /** <meta name="description">. ~140-160 chars. */
   metaDescription: string;
   /** SEO keywords. */
@@ -55,6 +58,8 @@ export const services: Service[] = [
     title: 'Agents IA et assistants conversationnels sur mesure',
     tagline:
       'Un agent qui exécute trois workflows précis dans votre produit, pas un chatbot vitrine de plus.',
+    outcome:
+      "Vos équipes arrêtent de trier, qualifier et répondre à la main sur les tâches répétitives. Un agent prend en charge trois actions précises de votre quotidien et passe la main à un humain dès qu'il sort de son périmètre — pas de réponse inventée, pas de dérapage.",
     metaDescription:
       "Intégration d'agents conversationnels dans votre stack web : appels d'outils internes, garde-fous, eval continue. Développeur full-stack freelance, Paris.",
     keywords: [
@@ -124,6 +129,8 @@ export const services: Service[] = [
     title: 'RAG et recherche sémantique sur vos documents',
     tagline:
       'Vos documents internes interrogeables en langage naturel, avec citation obligatoire vers la source.',
+    outcome:
+      "Vos équipes retrouvent en quelques secondes la bonne information noyée dans des années de documents, avec la source à l'appui pour vérifier. Fini le « demande à Untel » qui ne passe pas à l'échelle, et fini les réponses qui ressemblent à la vérité sans en être.",
     metaDescription:
       'Recherche sémantique sur vos documents internes : pgvector ou Qdrant, embeddings adaptés à votre langue, citations vérifiables, eval continue. Freelance Paris.',
     keywords: [
@@ -195,6 +202,8 @@ export const services: Service[] = [
     title: 'Automatisations LLM sur mesure pour vos processus métier',
     tagline:
       'Pipelines en prod pour vos process répétitifs : classification, extraction, scoring, génération encadrée.',
+    outcome:
+      "Une tâche répétitive sur du texte — classer, extraire, rédiger, scorer — passe de plusieurs heures humaines par jour à un traitement automatique, à un coût connu d'avance et suivi mois après mois. Votre équipe récupère ce temps pour ce qui compte vraiment.",
     metaDescription:
       'Pipelines LLM en production sur vos process métier : classification, extraction structurée, scoring, génération. Coûts tokens trackés, eval automatique, retry.',
     keywords: [
@@ -264,6 +273,8 @@ export const services: Service[] = [
     title: 'Applications web sur mesure (Next.js, TypeScript, Node.js)',
     tagline:
       'Sites vitrines, applications métier, plateformes SaaS. Du cadrage au déploiement, par un dev qui code en Next.js et Rails depuis 4 ans.',
+    outcome:
+      'Vous obtenez une application qui sort, qui tourne et que vos utilisateurs utilisent vraiment — du cadrage à la mise en ligne, en livraisons régulières, sans tunnel de plusieurs mois où vous ne voyez rien avancer.',
     metaDescription:
       "Développeur full-stack freelance à Paris. Applications web sur mesure en Next.js, TypeScript, Node.js, Ruby on Rails et PostgreSQL. 4 ans d'expérience, dont 2 sur du Rails métier.",
     keywords: [
@@ -327,6 +338,8 @@ export const services: Service[] = [
     title: 'Refonte et interventions ponctuelles',
     tagline:
       "Site lent, framework abandonné, bug en prod qui revient. Vous n'avez pas besoin d'un projet de 3 mois, juste de quelqu'un qui ouvre le capot et répare.",
+    outcome:
+      'Votre site existant redevient rapide, stable et maintenable — sans tout réécrire ni casser votre référencement. Vous payez du temps d’intervention ciblé, facturé à la demi-journée, pas un forfait de refonte que vous ne vouliez pas.',
     metaDescription:
       'Interventions ponctuelles sur site existant : migration de framework, optimisation Core Web Vitals, fix de bug en prod, ajout de fonctionnalité. Demi-journée minimum, devis avant intervention.',
     keywords: [
@@ -390,6 +403,8 @@ export const services: Service[] = [
     title: 'Conseil et audit IA : cadrage, arbitrage, revue',
     tagline:
       "Avant de coder, on regarde si l'IA est vraiment le bon outil. Audit indépendant pour PME et scale-ups, livré en note synthétique signée.",
+    outcome:
+      'Vous prenez votre décision IA en connaissance de cause : ce que ça coûte, ce que ça rapporte, et si ça vaut le coup. Le tout dans une note écrite et signée, lisible en comité de direction — pas un argumentaire déguisé pour vous vendre la mission qui suit.',
     metaDescription:
       "Audit IA et cadrage de prototype LLM pour PME et scale-ups. Arbitrage de stack, estimation coûts tokens, revue d'architecture. Note synthétique remise sous 1 à 5 jours.",
     keywords: [


### PR DESCRIPTION
**Étape 3/4 de la refonte.** Registre retenu : *résultat business d'abord, profondeur technique ensuite.*

> 📌 PR **empilée** sur l'étape 2 (#58). Ordre de fusion : #56 → #57 → #58 → cette PR → `master`.

## Pourquoi

Les pages service répondaient très bien au **CTO évaluateur** (eval, coûts tokens, retry, archi) mais **ouvraient sur du langage technique** (RAG, agents, recall@k) qui perd le **dirigeant non-technique** — or c'est lui qui tient le budget. Une seule voix servait deux publics ; elle penchait trop « ingénieur ».

## Le « double-étage »

- **Étage 1 — dirigeant** : nouveau champ `Service.outcome`, le *résultat concret pour le client* en langage business sans jargon. Rendu en tête de page service sous l'eyebrow **« Le résultat pour vous »**, **avant** le contexte et l'approche.
- **Étage 2 — CTO** : toute la profondeur technique existante reste, juste un cran plus bas. Rien retiré.

Le visiteur lit d'abord *« ça m'apporte quoi »*, puis *« comment c'est fait »*.

Exemples d'`outcome` :
- *Agents IA* → « Vos équipes arrêtent de trier, qualifier et répondre à la main… l'agent passe la main à un humain dès qu'il sort de son périmètre. »
- *RAG* → « Vos équipes retrouvent en quelques secondes la bonne info noyée dans des années de documents, avec la source à l'appui. »
- *Conseil & audit* → « Vous prenez votre décision IA en connaissance de cause : ce que ça coûte, ce que ça rapporte, et si ça vaut le coup. »

## Vérifications

- `bun run type-check` ✅
- `bun run lint` ✅
- `bun run test` ✅ — 102/102
- `prettier --check` ✅

## Suite

4/4 — Conversion & technique : modale Cal inline (au lieu du nouvel onglet), vraie preuve sociale, retour au scroll natif (gain mobile), + réordonnancement home (cluster preuve sociale).

https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi

---
_Generated by [Claude Code](https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi)_