### PR TITLE
Refonte conversion — étape 4/4 : modale Cal, preuve factuelle, ordre home

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import ScrollView from '@/components/ScrollView';
 import BackToTop from '@/components/BackToTop';
 import HeaderBar from '@/components/HeaderBar';
 import Footer from '@/components/Footer';
+import CalEmbedScript from '@/components/CalEmbedScript';
 import MetaTags from './components/MetaTags';
 import JsonLdScripts from './components/JsonLdScripts';
 
@@ -145,6 +146,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Suspense fallback={null}>
           <BackToTop />
         </Suspense>
+
+        {/* Cal.com embed — réservation en modale inline (cf. CalPopupButton) */}
+        <CalEmbedScript />
 
         {/* Umami Analytics - privacy-friendly, no cookies */}
         <Script

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,10 +26,10 @@ export default function Home() {
       <Hero />
       <Services />
       <Projects />
+      <Testimonials />
       <Process />
       <FAQ />
       <LatestPosts posts={latestPosts} />
-      <Testimonials />
       <Contact />
     </main>
   );

--- a/components/CalEmbedScript.tsx
+++ b/components/CalEmbedScript.tsx
@@ -1,0 +1,20 @@
+import Script from 'next/script';
+
+/**
+ * Charge l'embed Cal.com et ouvre la réservation en modale inline au clic
+ * sur tout élément portant `data-cal-link` (cf. CalPopupButton), sans quitter
+ * le site — meilleure conversion qu'un saut vers un nouvel onglet.
+ *
+ * Loader officiel Cal.com. `strategy="afterInteractive"` : ne bloque pas le
+ * rendu ; tant qu'il n'est pas exécuté, les boutons restent de simples liens
+ * `<a href>` fonctionnels (repli sans JS).
+ */
+export default function CalEmbedScript() {
+  return (
+    <Script id="cal-embed" strategy="afterInteractive">
+      {`(function (C, A, L) { let p = function (a, ar) { a.q.push(ar); }; let d = C.document; C.Cal = C.Cal || function () { let cal = C.Cal; let ar = arguments; if (!cal.loaded) { cal.ns = {}; cal.q = cal.q || []; d.head.appendChild(d.createElement("script")).src = A; cal.loaded = true; } if (ar[0] === L) { const api = function () { p(api, arguments); }; const namespace = ar[1]; api.q = api.q || []; if(typeof namespace === "string"){cal.ns[namespace] = cal.ns[namespace] || api;p(cal.ns[namespace], ar);p(cal, ["initNamespace", namespace]);} else p(cal, ar); return;} p(cal, ar); }; })(window, "https://app.cal.com/embed/embed.js", "init");
+Cal("init", { origin: "https://cal.com" });
+Cal("ui", { theme: "dark", cssVarsPerTheme: { dark: { "cal-brand": "#6366f1" } }, hideEventTypeDetails: false, layout: "month_view" });`}
+    </Script>
+  );
+}

--- a/components/CalPopupButton.tsx
+++ b/components/CalPopupButton.tsx
@@ -1,7 +1,12 @@
 import { type ReactNode } from 'react';
 
-const CAL_URL =
-  'https://cal.com/victor-lenain-ejsjfb/echange-decouverte?theme=dark&layout=month_view';
+/* Lien Cal.com. `CAL_LINK` = chemin public (namespace/event), consommé par
+ * l'embed pour ouvrir la réservation en MODALE inline (cf. CalEmbedScript).
+ * On reste sur un vrai `<a href>` : si le script d'embed n'est pas encore
+ * chargé (ou échoue), le clic ouvre Cal dans un onglet comme avant —
+ * amélioration progressive, jamais de régression sur le CTA principal. */
+const CAL_LINK = 'victor-lenain-ejsjfb/echange-decouverte';
+const CAL_URL = `https://cal.com/${CAL_LINK}?theme=dark&layout=month_view`;
 
 type CalPopupButtonProps = {
   children: ReactNode;
@@ -11,7 +16,15 @@ type CalPopupButtonProps = {
 
 export default function CalPopupButton({ children, className, ...rest }: CalPopupButtonProps) {
   return (
-    <a {...rest} className={className} href={CAL_URL} rel="noopener noreferrer" target="_blank">
+    <a
+      {...rest}
+      className={className}
+      data-cal-config='{"layout":"month_view","theme":"dark"}'
+      data-cal-link={CAL_LINK}
+      href={CAL_URL}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
       {children}
     </a>
   );

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -2,37 +2,80 @@ import Section from '@/components/Section';
 import FadeOnView from '@/components/FadeOnView';
 
 /**
- * Pas de témoignage inventé. Le slot "Votre retour ici" sert d'appel à
- * témoignage authentique. À remplir au fur et à mesure des retours clients
- * réels (LinkedIn recommendations, retours mission, captures Slack signées).
+ * Preuve sociale SANS témoignage inventé. Tant qu'il n'y a pas de retour
+ * client réel, on s'appuie sur des faits vérifiables déjà vrais ailleurs sur
+ * le site (produits en prod, expérience, code open-source, réactivité) —
+ * une preuve factuelle convertit mieux qu'un encart « témoignage » vide.
+ * Le bloc d'invitation reste pour collecter de vrais retours, à afficher
+ * ici dès qu'ils existent (recommandations LinkedIn, retours mission signés).
  */
+
+const proofs: { stat: string; label: string; detail: string }[] = [
+  {
+    stat: '2',
+    label: 'produits IA livrés en solo',
+    detail: 'AubeSonore en production depuis 2025, TomIA en pré-prod pour 2026.',
+  },
+  {
+    stat: '4 ans',
+    label: 'de code en production',
+    detail: 'Dont 2 ans en Rails chez Capsens (fintech, 2022-2024).',
+  },
+  {
+    stat: 'Open source',
+    label: 'briques vérifiables avant signature',
+    detail: 'Serveur MCP, démo RAG, pipeline d’eval — lisibles publiquement.',
+  },
+  {
+    stat: '< 24 h',
+    label: 'délai de réponse',
+    detail: 'Réponse sous 24 h ouvrées, démarrage sous 1 à 2 semaines.',
+  },
+];
 
 export default function Testimonials() {
   return (
     <Section className="scroll-mt-28 pb-20" id="temoignages">
       <FadeOnView className="mb-12 max-w-2xl">
-        <p className="label-mono mb-3 text-brand-accent">Retour mission</p>
-        <h2 className="heading-2 text-white">On a déjà travaillé ensemble ?</h2>
+        <p className="label-mono mb-3 text-brand-accent">Preuve</p>
+        <h2 className="heading-2 text-white">Ce qui tourne déjà, pour de vrai.</h2>
         <p className="mt-5 text-base leading-relaxed text-gray-400">
-          Un retour court sur la collaboration aide énormément les futurs clients à se décider.
-          Anonyme si vous préférez.
+          Pas de logo client ni de témoignage inventé. Juste des faits vérifiables — du code en
+          production et lisible avant qu&apos;on signe quoi que ce soit.
         </p>
       </FadeOnView>
 
-      <div className="mx-auto max-w-2xl">
-        <FadeOnView
-          className="flex flex-col items-start gap-5 rounded-2xl border border-dashed border-line-4 bg-surface-1 p-7 text-left"
-          delay={0.1}
-        >
-          <p className="label-mono text-gray-500">Votre retour ici</p>
-          <a
-            className="inline-flex w-fit items-center gap-1.5 text-sm font-medium text-brand-light transition-colors hover:text-brand-lighter"
-            href="mailto:victor.lenain26@gmail.com?subject=Retour%20mission"
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {proofs.map((p, i) => (
+          <FadeOnView
+            key={p.label}
+            className="flex flex-col gap-2 rounded-2xl border border-line-2 bg-surface-1 p-6 backdrop-blur-sm"
+            delay={0.05 + i * 0.05}
           >
-            Envoyer un retour →
-          </a>
-        </FadeOnView>
+            <span className="font-display text-3xl font-bold text-white sm:text-4xl">{p.stat}</span>
+            <span className="text-sm font-semibold text-brand-light">{p.label}</span>
+            <span className="text-xs leading-relaxed text-gray-500">{p.detail}</span>
+          </FadeOnView>
+        ))}
       </div>
+
+      {/* Invitation à un vrai retour client — remplacera/complétera ce bloc
+       * dès qu'un témoignage signé est disponible. */}
+      <FadeOnView
+        className="mt-8 flex flex-col items-start justify-between gap-4 rounded-2xl border border-dashed border-line-4 bg-surface-1 p-6 sm:flex-row sm:items-center"
+        delay={0.25}
+      >
+        <p className="text-sm leading-relaxed text-gray-400">
+          On a déjà travaillé ensemble ? Un retour court aide les prochains clients à se décider —
+          anonyme si vous préférez.
+        </p>
+        <a
+          className="inline-flex w-fit shrink-0 items-center gap-1.5 text-sm font-medium text-brand-light transition-colors hover:text-brand-lighter"
+          href="mailto:victor.lenain26@gmail.com?subject=Retour%20mission"
+        >
+          Envoyer un retour →
+        </a>
+      </FadeOnView>
     </Section>
   );
 }


### PR DESCRIPTION
**Étape 4/4 de la refonte** (dernière). Objectif : lever les derniers freins à la conversion.

> 📌 PR **empilée** sur l'étape 3 (#59). Ordre de fusion final : #56 → #57 → #58 → #59 → cette PR → `master`.

## Changements

### 🔴 Modale Cal.com inline (au lieu du nouvel onglet)
Le CTA principal du site (« Réserver ») ouvrait cal.com **dans un nouvel onglet** → sortie du site, perte de contexte, drop-off. Désormais le clic ouvre la réservation **en modale par-dessus la page**.
- Implémenté via l'**embed officiel Cal.com par script** (`CalEmbedScript`), **sans dépendance npm** ajoutée.
- **Repli sûr / amélioration progressive** : les boutons restent de vrais `<a href>` ciblant cal.com. Si le script n'est pas (encore) chargé ou échoue, le clic se comporte comme avant. **Aucune régression possible** sur le CTA principal.
- Thème dark + couleur de marque (`#6366f1`) passés à l'embed pour rester cohérent.

### 🟠 Preuve sociale honnête (sans rien inventer)
La section témoignages était un slot **vide** (« Votre retour ici ») — contre-productif (signale « pas de clients »). Remplacée par un bandeau de **faits vérifiables** déjà vrais ailleurs sur le site :
- 2 produits IA livrés en prod · 4 ans de code (dont 2 en Rails chez Capsens) · briques open source lisibles avant signature · réponse < 24 h.
- L'invitation à un vrai retour client est conservée (pour collecter de vrais témoignages à afficher ici ensuite).
- **Aucun témoignage inventé** — quand tu auras de vrais retours signés, on les ajoutera.

### 🟡 Réordonnancement de la home
Regroupement logique du parcours : Hero → **Services (offre)** → **Projets + Preuve (preuve groupée)** → Méthode → FAQ (objections) → Blog → Contact (clôture). La preuve suit immédiatement l'offre, au lieu d'être isolée en bas de page.

## Reporté volontairement
Le **passage au scroll natif** (retrait de Radix ScrollArea) n'est **pas** dans cette PR : c'est le changement le plus risqué (layout racine, header, back-to-top) et il demande une vérification navigateur. À traiter dans une PR isolée si tu le souhaites, sur la preview.

## Vérifications
- `bun run type-check` ✅
- `bun run lint` ✅ (warnings préexistants)
- `bun run test` ✅ — 102/102
- `bun run build` ✅ — 35 pages générées

https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi

---
_Generated by [Claude Code](https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi)_