### PR TITLE
Retour au scroll natif du document (gain mobile)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -107,6 +107,34 @@
     scroll-behavior: smooth;
   }
 
+  /* Scrollbar native stylée (desktop). Sur tactile, on laisse le navigateur
+   * gérer pour préserver le repli de la barre d'URL et le momentum natif. */
+  @media (hover: hover) and (pointer: fine) {
+    html {
+      scrollbar-width: thin;
+      scrollbar-color: var(--color-brand-hover) transparent;
+    }
+
+    ::-webkit-scrollbar {
+      width: 10px;
+    }
+
+    ::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background-color: var(--color-line-5);
+      border: 3px solid transparent;
+      background-clip: content-box;
+      border-radius: 9999px;
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+      background-color: var(--color-brand-hover);
+    }
+  }
+
   @media (prefers-reduced-motion: reduce) {
     html {
       scroll-behavior: auto;

--- a/components/BackToTop.tsx
+++ b/components/BackToTop.tsx
@@ -12,24 +12,15 @@ export default function BackToTop() {
 
   /* ----------- Observer / Listener ----------- */
   useEffect(() => {
-    const viewport = document.getElementById('scroll-viewport');
-    if (!viewport) {
-      return;
-    }
+    const canScroll = () =>
+      document.documentElement.scrollHeight > document.documentElement.clientHeight;
 
     const hero = document.getElementById('accueil');
 
-    const canScroll = () => viewport.scrollHeight > viewport.clientHeight;
-
     if (hero && pathname === '/') {
-      const io = new IntersectionObserver(
-        ([e]) => {
-          setVisible(canScroll() && !e?.isIntersecting);
-        },
-        {
-          root: viewport,
-        },
-      );
+      const io = new IntersectionObserver(([e]) => {
+        setVisible(canScroll() && !e?.isIntersecting);
+      });
       io.observe(hero);
       return () => {
         io.disconnect();
@@ -38,35 +29,21 @@ export default function BackToTop() {
 
     const SCROLL_THRESHOLD = 120;
     const onScroll = () => {
-      setVisible(canScroll() && viewport.scrollTop > SCROLL_THRESHOLD);
+      setVisible(canScroll() && window.scrollY > SCROLL_THRESHOLD);
     };
-    viewport.addEventListener('scroll', onScroll, { passive: true });
-    viewport.addEventListener('resize', onScroll);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
     onScroll();
     return () => {
-      viewport.removeEventListener('scroll', onScroll);
-      viewport.removeEventListener('resize', onScroll);
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
     };
   }, [pathname]);
 
   /* ----------- Handler « remonter » ----------- */
   const scrollToTop = (e: React.MouseEvent) => {
     e.preventDefault();
-
-    const behavior = getScrollBehavior();
-
-    const hero = document.getElementById('accueil');
-    if (hero) {
-      hero.scrollIntoView({ behavior, block: 'start' });
-      return;
-    }
-
-    const viewport = document.getElementById('scroll-viewport');
-    if (viewport) {
-      viewport.scrollTo({ top: 0, behavior });
-    } else {
-      window.scrollTo({ top: 0, behavior });
-    }
+    window.scrollTo({ top: 0, behavior: getScrollBehavior() });
   };
 
   /* ----------- Render ----------- */

--- a/components/HeaderBar.tsx
+++ b/components/HeaderBar.tsx
@@ -49,23 +49,19 @@ export default function HeaderBar() {
   const [scrolled, setScrolled] = useState(false);
 
   /* État "elevated" du header dès qu'on quitte le tout-haut. Listener passif
-   * sur le scroll-viewport (Radix ScrollArea), peu coûteux et plus précis
-   * qu'un IO pour ce binaire. */
+   * sur le scroll natif du document, peu coûteux et plus précis qu'un IO pour
+   * ce binaire. */
   useEffect(() => {
-    const viewport = document.getElementById('scroll-viewport');
-    if (!viewport) return;
     const onScroll = () => {
-      setScrolled(viewport.scrollTop > 8);
+      setScrolled(window.scrollY > 8);
     };
     onScroll();
-    viewport.addEventListener('scroll', onScroll, { passive: true });
-    return () => viewport.removeEventListener('scroll', onScroll);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
   useEffect(() => {
     if (!onHomepage) return;
-
-    const root = (document.getElementById('scroll-viewport') as Element | null) ?? null;
 
     const visibleSections = new Map<string, number>();
 
@@ -95,7 +91,6 @@ export default function HeaderBar() {
         setActiveSection(chosen);
       },
       {
-        root,
         rootMargin: '-120px 0px -55% 0px',
         threshold: [0, 0.25, 0.5, 0.75, 1],
       },
@@ -119,9 +114,7 @@ export default function HeaderBar() {
     (e: React.MouseEvent) => {
       if (!onHomepage) return;
       e.preventDefault();
-      document
-        .getElementById('scroll-viewport')
-        ?.scrollTo({ top: 0, behavior: getScrollBehavior() });
+      window.scrollTo({ top: 0, behavior: getScrollBehavior() });
     },
     [onHomepage],
   );

--- a/components/ScrollView.tsx
+++ b/components/ScrollView.tsx
@@ -1,57 +1,25 @@
-'use client';
-
-import { useEffect, useRef } from 'react';
-import { usePathname } from 'next/navigation';
-import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
-import { cn } from '@/lib/utils';
+import { type ReactNode } from 'react';
 
 /**
- * Plein-écran scroll wrapper.
+ * Wrapper de contenu.
  *
- * Décisions UI :
- *  - `type="scroll"` : la scrollbar n'apparaît qu'au moment du scroll, puis
- *    s'estompe. Pattern dominant 2026 (Linear, Vercel, Stripe). Zéro
- *    distraction visuelle pendant la lecture.
- *  - Scrollbar scopée SOUS le header (h-14 mobile, h-16 desktop). Elle ne
- *    traverse plus la zone du header translucide, qui restait illisible
- *    derrière la barre dégradée.
+ * Historiquement, le site scrollait dans un conteneur Radix ScrollArea
+ * (`#scroll-viewport`) en `height: 100dvh; overflow: hidden`. Ça donnait une
+ * jolie scrollbar custom, mais au prix de régressions réelles sur mobile :
+ *  - la barre d'URL du navigateur ne se repliait plus au scroll (≈ 60-100px
+ *    de hauteur utile perdus en permanence) ;
+ *  - pas de restauration de scroll native entre les navigations ;
+ *  - momentum iOS, Ctrl+F « scroll-into-view » et ancres externes fragilisés.
+ *
+ * On revient donc au scroll natif du document. La scrollbar est stylée en CSS
+ * (cf. globals.css, desktop uniquement) pour conserver l'esthétique sans aucun
+ * de ces coûts. Next.js gère lui-même le reset de scroll à la navigation, et
+ * les consommateurs (`HeaderBar`, `BackToTop`, `useFadeOnView`) observent
+ * désormais le viewport du document.
+ *
+ * Composant conservé comme point d'extension et pour ne pas toucher au graphe
+ * d'imports du layout.
  */
-export default function ScrollView({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
-  const viewportRef = useRef<HTMLDivElement>(null);
-  const pathname = usePathname();
-
-  useEffect(() => {
-    viewportRef.current?.scrollTo({ top: 0, left: 0, behavior: 'instant' });
-  }, [pathname]);
-
-  return (
-    <ScrollAreaPrimitive.Root
-      className={cn('relative h-[100dvh] w-full overflow-hidden', className)}
-      scrollHideDelay={600}
-      type="scroll"
-      {...props}
-    >
-      <ScrollAreaPrimitive.Viewport
-        ref={viewportRef}
-        className="h-full w-full rounded-[inherit]"
-        id="scroll-viewport"
-      >
-        {children}
-      </ScrollAreaPrimitive.Viewport>
-
-      {/* Rail vertical : commence sous le header pour ne pas le traverser */}
-      <ScrollAreaPrimitive.Scrollbar
-        className="absolute top-14 right-0 h-[calc(100%-3.5rem)] w-2 p-px transition-opacity data-[state=hidden]:opacity-0 lg:top-16 lg:h-[calc(100%-4rem)]"
-        orientation="vertical"
-      >
-        <ScrollAreaPrimitive.Thumb className="flex-1 rounded-full bg-gradient-to-b from-brand-hover/80 to-violet-400/80" />
-      </ScrollAreaPrimitive.Scrollbar>
-
-      <ScrollAreaPrimitive.Corner />
-    </ScrollAreaPrimitive.Root>
-  );
+export default function ScrollView({ children }: { children: ReactNode }) {
+  return <>{children}</>;
 }

--- a/hooks/useFadeOnView.ts
+++ b/hooks/useFadeOnView.ts
@@ -3,13 +3,12 @@
 import { useEffect, useRef, useState } from 'react';
 
 /**
- * Reveals an element with a CSS fade-up when it enters the scroll viewport.
+ * Reveals an element with a CSS fade-up when it enters the viewport.
  * Replaces the repeated Framer Motion `fadeUp` pattern with a lighter
  * IntersectionObserver-based approach. Honors `prefers-reduced-motion`
  * (handled in CSS).
  *
- * Bound to `#scroll-viewport` (the Radix ScrollArea viewport used by the
- * layout). Falls back to the document viewport if missing.
+ * Observes against the document viewport (native scroll).
  */
 export function useFadeOnView<T extends HTMLElement = HTMLDivElement>() {
   const ref = useRef<T | null>(null);
@@ -18,8 +17,6 @@ export function useFadeOnView<T extends HTMLElement = HTMLDivElement>() {
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-
-    const root = (document.getElementById('scroll-viewport') as Element | null) ?? null;
 
     const io = new IntersectionObserver(
       entries => {
@@ -32,7 +29,6 @@ export function useFadeOnView<T extends HTMLElement = HTMLDivElement>() {
         }
       },
       {
-        root,
         rootMargin: '0px 0px -8% 0px',
         threshold: 0.05,
       },


### PR DESCRIPTION
## Pourquoi

Le site scrollait dans un conteneur Radix ScrollArea (`height: 100dvh; overflow: hidden`). Joli rendu de scrollbar, mais plusieurs coûts réels sur mobile :
- la barre d'URL du navigateur ne se repliait plus au scroll (≈ 60-100px de hauteur utile perdus en permanence) ;
- pas de restauration de scroll native entre les navigations ;
- momentum iOS, Ctrl+F « scroll-into-view » et ancres externes fragilisés.

## Changements

- `ScrollView` devient un simple passthrough (Next.js gère le reset de scroll à la navigation).
- `HeaderBar`, `BackToTop` et `useFadeOnView` observent désormais le viewport du document / `window` au lieu de `#scroll-viewport`.
- Scrollbar **native stylée en CSS**, desktop uniquement (`hover: hover` + `pointer: fine`). Sur tactile, on laisse le navigateur gérer pour préserver le repli de la barre d'URL et le momentum natif.
- `@radix-ui/react-scroll-area` n'est plus utilisé (retrait de la dépendance à faire séparément).

## À vérifier en preview (raison pour laquelle cette PR était en attente)

C'est le changement le plus structurel de la refonte (layout racine). Points à regarder sur la preview Vercel :
- **mobile** : la barre d'URL se replie bien au scroll, momentum fluide ;
- **navigation** : scroll remis en haut en changeant de page, position restaurée au retour arrière ;
- **desktop** : scrollbar stylée visible et lisible, header qui passe en "elevated", bouton « remonter » qui apparaît après le hero.

## Vérifications
- `bun run type-check` ✅
- `bun run lint` ✅
- `bun run test` ✅ — 102/102
- `bun run build` ✅ (vérifié avant le merge de master)

https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi

---
_Generated by [Claude Code](https://claude.ai/code/session_016SUXkmABf43xZ2m5fyXxVi)_